### PR TITLE
Release 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release 6.0
 
+* Update version number to match framework version (6.x)
+* Update projects to be net6.0
+* Update nuget dependencies to latest stable versions
+* Update to latest RestSharp and handle breaking changes
+* Set X-Forwarded-For header on client requests that originated from httprequest to capture original client ip
+* Improved authenticator logging
+
 |Commit|Date|Author|Message|
 |---|---|---|---|
 | 6fb4e8b | <span style="white-space:nowrap;">2023-06-15</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  update version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update to latest RestSharp and handle breaking changes
 * Set X-Forwarded-For header on client requests that originated from httprequest to capture original client ip
 * Improved authenticator logging
+* Handle deserialization exception when throw is true
 
 |Commit|Date|Author|Message|
 |---|---|---|---|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# Release 6.0
+
+|Commit|Date|Author|Message|
+|---|---|---|---|
+| 6fb4e8b | <span style="white-space:nowrap;">2023-06-15</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  update version
+| c28b6e9 | <span style="white-space:nowrap;">2023-06-20</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  Merge branch 'master' into develop
+| 1400841 | <span style="white-space:nowrap;">2023-06-23</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  [net6] update to net6
+| bb7b232 | <span style="white-space:nowrap;">2023-06-23</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  [net6] update to latest restsharp library
+| d9744b8 | <span style="white-space:nowrap;">2023-06-23</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  [net6] use vs2022 builder image
+| 5e0f21b | <span style="white-space:nowrap;">2023-06-23</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  (origin/net6, net6) [net6] add useful message to when token parsing is not successful
+| 4c336fd | <span style="white-space:nowrap;">2023-06-23</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  Merge pull request #15 from cortside/net6
+| 541bc53 | <span style="white-space:nowrap;">2023-07-17</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  update version to 6.x to be in line with dotnet and net6 version numbers
+| 65ac8c9 | <span style="white-space:nowrap;">2023-07-17</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  update version to 6.x to be in line with dotnet and net6 version numbers
+| 85bbf9c | <span style="white-space:nowrap;">2023-07-25</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  set X-Forwarded-For header on client requests that originated from httprequest to capture original client ip
+| 7a47485 | <span style="white-space:nowrap;">2023-07-26</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  set X-Forwarded-For header on client requests that originated from httprequest to capture original client ip
+| 35d06d0 | <span style="white-space:nowrap;">2023-07-26</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  set X-Forwarded-For header on client requests that originated from httprequest to capture original client ip
+| d96fafe | <span style="white-space:nowrap;">2023-07-26</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  allow for any ILogger in authenticator
+| d66d8a4 | <span style="white-space:nowrap;">2023-07-27</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  add more tests for delegation and better validation if there is reason to attempt to delegate
+| 346d497 | <span style="white-space:nowrap;">2023-08-15</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  [OR-2315] handle deserialization exception when throw is true
+| 82eaaea | <span style="white-space:nowrap;">2023-08-15</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  (origin/OR-2315, OR-2315) nudge for build
+| 5a21159 | <span style="white-space:nowrap;">2023-08-29</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  Merge pull request #16 from cortside/OR-2315
+| ecbcdd4 | <span style="white-space:nowrap;">2023-08-30</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  (HEAD -> release/6.0, origin/develop, origin/HEAD, develop) update to latest nuget packages
+****
+
 # Release 1.2
 
 |Commit|Date|Author|Message|

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 
 image: Visual Studio 2019
 
-version: 1.2.{build}
+version: 1.3.{build}
 
 configuration:
 - Debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 ## https://www.appveyor.com/docs/appveyor-yml/
 
-image: Visual Studio 2019
+image: Previous Visual Studio 2022
 
 version: 1.3.{build}
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 
 image: Previous Visual Studio 2022
 
-version: 1.3.{build}
+version: 6.0.{build}
 
 configuration:
 - Debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 ## https://www.appveyor.com/docs/appveyor-yml/
-
 image: Previous Visual Studio 2022
 
 version: 6.0.{build}
@@ -99,8 +98,6 @@ cache:
   
 nuget:
   disable_publish_on_pr: true
-#  account_feed: true
-#  project_feed: true
   
 deploy:
 - provider: NuGet

--- a/src/Cortside.RestApiClient.Tests/Authenticators/DelegationTest.cs
+++ b/src/Cortside.RestApiClient.Tests/Authenticators/DelegationTest.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Cortside.MockServer;
+using Cortside.MockServer.AccessControl;
+using Cortside.RestApiClient.Authenticators.OpenIDConnect;
+using Cortside.RestApiClient.Tests.Mocks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Primitives;
+using Polly;
+using RestSharp;
+using Xunit;
+
+namespace Cortside.RestApiClient.Tests.Authenticators {
+    public class DelegationTest {
+        private readonly RestClient client;
+
+        public static MockHttpServer Server { get; set; }
+
+        public DelegationTest() {
+            var name = Guid.NewGuid().ToString();
+
+            // JWT tokens can be generated with defined values using this site: http://jwtbuilder.jamiekurtz.com/
+            Server = new MockHttpServer(name)
+                .ConfigureBuilder(new SubjectMock("./Data/subjects.json"))
+                .ConfigureBuilder<TestMock>()
+                .ConfigureBuilder<DelegationGrantMock>();
+
+            Server.WaitForStart();
+            client = new RestClient(Server.Url);
+        }
+
+        public OpenIDConnectAuthenticator GetAuthenticator(string clientId, string token) {
+            var tokenRequest = new TokenRequest {
+                AuthorityUrl = Server.Url,
+                GrantType = "client_credentials",
+                Scope = "scope",
+                ClientId = clientId,
+                ClientSecret = "secret"
+            };
+
+            // arrange
+            var header = new KeyValuePair<string, StringValues>("Authorization", new StringValues(token));
+            var context = GetHttpContext("host", "/path", header);
+
+            var authenticator = new OpenIDConnectAuthenticator(context, tokenRequest)
+                .UsePolicy(PolicyBuilderExtensions.Handle<Exception>()
+                    .OrResult(r => r.StatusCode == HttpStatusCode.Unauthorized || r.StatusCode == 0)
+                    .WaitAndRetryAsync(PolicyBuilderExtensions.Jitter(1, 2))
+                )
+                .UseLogger(new NullLogger<OpenIDConnectAuthenticator>());
+
+            return authenticator;
+        }
+
+        public static IHttpContextAccessor GetHttpContext(string host, string requestPath, KeyValuePair<string, StringValues> header) {
+            var context = new DefaultHttpContext {
+                Request = {
+                    Path = requestPath,
+                    Host = new HostString(host),
+                    Headers = {  }
+                }
+            };
+
+            if (!string.IsNullOrWhiteSpace(header.Value)) {
+                context.Request.Headers.Add(header.Key, header.Value);
+            }
+
+            var obj = new HttpContextAccessor();
+            obj.HttpContext = context;
+            return obj;
+        }
+
+        [Fact]
+        public async Task ShouldNotDelegate_NoRequestToken() {
+            // arrange
+            var authenticator = GetAuthenticator("foo", "");
+            var request = new RestRequest("/api/v1/items/1234", Method.Get);
+
+            // act
+            await authenticator.Authenticate(client, request).ConfigureAwait(false);
+
+            // assert
+            var authorization = request.Parameters.FirstOrDefault(x => x.Type == ParameterType.HttpHeader && x.Name == KnownHeaders.Authorization)?.Value?.ToString();
+            Assert.NotNull(authorization);
+            Assert.Contains("foo-client_credentials-token", authorization);
+        }
+
+        [Fact]
+        public async Task ShouldDelegate() {
+            // arrange
+            var authenticator = GetAuthenticator("allow", "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2OTA0ODIyNzEsImV4cCI6MTcyMjAxODI3MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsImdyYW50X3R5cGUiOiJkZWxlZ2F0aW9uIn0.x43mQWtHy_ubj36gMXuoYtqp6K32w9XVuooYXWWVQNo");
+            var request = new RestRequest("/api/v1/items/1234", Method.Get);
+
+            // act
+            await authenticator.Authenticate(client, request).ConfigureAwait(false);
+
+            // assert
+            var authorization = request.Parameters.FirstOrDefault(x => x.Type == ParameterType.HttpHeader && x.Name == KnownHeaders.Authorization)?.Value?.ToString();
+            Assert.NotNull(authorization);
+            Assert.Contains("allow-delegation-token", authorization);
+        }
+
+        [Fact]
+        public async Task ShouldNotDelegate() {
+            // arrange
+            var authenticator = GetAuthenticator("allow", "");
+            var request = new RestRequest("/api/v1/items/1234", Method.Get);
+
+            // act
+            await authenticator.Authenticate(client, request).ConfigureAwait(false);
+
+            // assert
+            var authorization = request.Parameters.FirstOrDefault(x => x.Type == ParameterType.HttpHeader && x.Name == KnownHeaders.Authorization)?.Value?.ToString();
+            Assert.NotNull(authorization);
+            Assert.Contains("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2OTA0ODIyNzEsImV4cCI6MTcyMjAxODI3MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsImdyYW50X3R5cGUiOiJkZWxlZ2F0aW9uIn0.x43mQWtHy_ubj36gMXuoYtqp6K32w9XVuooYXWWVQNo", authorization);
+        }
+    }
+}

--- a/src/Cortside.RestApiClient.Tests/Authenticators/OpenIDConnectAuthenticatorTest.cs
+++ b/src/Cortside.RestApiClient.Tests/Authenticators/OpenIDConnectAuthenticatorTest.cs
@@ -91,7 +91,7 @@ namespace Cortside.RestApiClient.Tests.Authenticators {
             // assert
             var authorization = request.Parameters.FirstOrDefault(x => x.Type == ParameterType.HttpHeader && x.Name == KnownHeaders.Authorization)?.Value?.ToString();
             Assert.NotNull(authorization);
-            Assert.True(authorization.Contains("delegation-token"));
+            Assert.Contains("delegation-token", authorization);
         }
 
         [Fact]

--- a/src/Cortside.RestApiClient.Tests/Authenticators/OpenIDConnectAuthenticatorTest.cs
+++ b/src/Cortside.RestApiClient.Tests/Authenticators/OpenIDConnectAuthenticatorTest.cs
@@ -91,7 +91,7 @@ namespace Cortside.RestApiClient.Tests.Authenticators {
             // assert
             var authorization = request.Parameters.FirstOrDefault(x => x.Type == ParameterType.HttpHeader && x.Name == KnownHeaders.Authorization)?.Value?.ToString();
             Assert.NotNull(authorization);
-            Assert.Contains("delegation-token", authorization);
+            Assert.Contains("foo-client_credentials-token", authorization);
         }
 
         [Fact]
@@ -201,7 +201,7 @@ namespace Cortside.RestApiClient.Tests.Authenticators {
             var token = await authenticator.GetTokenAsync();
 
             // assert
-            Assert.Equal("Bearer delegation-token", token);
+            Assert.Equal("Bearer foo-client_credentials-token", token);
         }
     }
 }

--- a/src/Cortside.RestApiClient.Tests/Clients/CatalogApi/CatalogClient.cs
+++ b/src/Cortside.RestApiClient.Tests/Clients/CatalogApi/CatalogClient.cs
@@ -29,7 +29,7 @@ namespace Cortside.RestApiClient.Tests.Clients.CatalogApi {
                 Cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
                 ThrowOnAnyError = throwOnAnyError
             };
-            client = new RestApiClient(logger, options);
+            client = new RestApiClient(logger, context, options);
         }
 
         internal async Task<RestResponse<CatalogItem>> GetItemAsync(string sku) {

--- a/src/Cortside.RestApiClient.Tests/Clients/CatalogApi/CatalogClient.cs
+++ b/src/Cortside.RestApiClient.Tests/Clients/CatalogApi/CatalogClient.cs
@@ -62,6 +62,14 @@ namespace Cortside.RestApiClient.Tests.Clients.CatalogApi {
             return response;
         }
 
+        public async Task<RestResponse> ModelMismatchAsync() {
+            var request = new RestApiRequest("/api/v1/jsonmodelmismatch", Method.Get) {
+                FollowRedirects = true,
+            };
+            var response = await client.ExecuteAsync<CatalogItem>(request).ConfigureAwait(false);
+            return response;
+        }
+
         public void Dispose() {
             Dispose(true);
             GC.SuppressFinalize(this);

--- a/src/Cortside.RestApiClient.Tests/Clients/GitHubApi/GitHubClient.cs
+++ b/src/Cortside.RestApiClient.Tests/Clients/GitHubApi/GitHubClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using RestSharp;
@@ -10,12 +11,12 @@ namespace Cortside.RestApiClient.Tests.Clients.GitHubApi {
         private readonly RestApiClient client;
         private readonly RestApiClientOptions options;
 
-        public GitHubClient(ILogger<GitHubClient> logger, IDistributedCache cache) {
+        public GitHubClient(ILogger<GitHubClient> logger, IDistributedCache cache, IHttpContextAccessor contextAccessor) {
             options = new RestApiClientOptions("https://api.github.com") {
                 Cache = cache
             };
 
-            client = new RestApiClient(logger, options);
+            client = new RestApiClient(logger, contextAccessor, options);
         }
 
         public IDistributedCache Cache => options.Cache;

--- a/src/Cortside.RestApiClient.Tests/Clients/HttpStatusApi/HttpStatusClient.cs
+++ b/src/Cortside.RestApiClient.Tests/Clients/HttpStatusApi/HttpStatusClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Polly;
 using RestSharp;
@@ -8,12 +9,12 @@ namespace Cortside.RestApiClient.Tests.Clients.HttpStatusApi {
     public class HttpStatusClient : IDisposable {
         readonly RestApiClient client;
 
-        public HttpStatusClient(ILogger<HttpStatusClient> logger, string hostUrl) {
-            client = new RestApiClient(logger, hostUrl);
+        public HttpStatusClient(ILogger<HttpStatusClient> logger, string hostUrl, IHttpContextAccessor contextAccessor) {
+            client = new RestApiClient(logger, contextAccessor, hostUrl);
         }
 
-        public HttpStatusClient(ILogger<HttpStatusClient> logger, RestApiClientOptions options) {
-            client = new RestApiClient(logger, options);
+        public HttpStatusClient(ILogger<HttpStatusClient> logger, IHttpContextAccessor contextAccessor, RestApiClientOptions options) {
+            client = new RestApiClient(logger, contextAccessor, options);
         }
 
         public async Task<string> Get200Async() {

--- a/src/Cortside.RestApiClient.Tests/Clients/LexisNexisApi/LexisNexisClient.cs
+++ b/src/Cortside.RestApiClient.Tests/Clients/LexisNexisApi/LexisNexisClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Cortside.RestApiClient.Tests.Clients.HttpStatusApi;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using RestSharp;
 using RestSharp.Authenticators;
@@ -9,13 +10,13 @@ namespace Cortside.RestApiClient.Tests.Clients.LexisNexisApi {
     public class LexisNexisClient : IDisposable {
         readonly RestApiClient client;
 
-        public LexisNexisClient(ILogger<HttpStatusClient> logger, LexisNexisClientConfiguration clientConfiguration) {
+        public LexisNexisClient(ILogger<HttpStatusClient> logger, LexisNexisClientConfiguration clientConfiguration, IHttpContextAccessor contextAccessor) {
             var options = new RestApiClientOptions {
                 BaseUrl = new Uri(clientConfiguration.ServiceUrl),
                 Authenticator = new HttpBasicAuthenticator(clientConfiguration.Username, clientConfiguration.Password),
                 XmlSerializer = true
             };
-            client = new RestApiClient(logger, options);
+            client = new RestApiClient(logger, contextAccessor, options);
         }
 
         internal async Task<RestResponse<InstantIDResponseEx>> InstantIdAsync() {

--- a/src/Cortside.RestApiClient.Tests/Cortside.RestApiClient.Tests.csproj
+++ b/src/Cortside.RestApiClient.Tests/Cortside.RestApiClient.Tests.csproj
@@ -9,18 +9,18 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Cortside.MockServer.AccessControl" Version="6.0.39-develop" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Cortside.MockServer.AccessControl" Version="6.0.44" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.6.40">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="WireMock.Net" Version="1.5.32" />
+    <PackageReference Include="WireMock.Net" Version="1.5.35" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cortside.RestApiClient.Tests/Cortside.RestApiClient.Tests.csproj
+++ b/src/Cortside.RestApiClient.Tests/Cortside.RestApiClient.Tests.csproj
@@ -1,43 +1,39 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
+    <NoWarn>1701;1702;VSTHRD200;</NoWarn>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AsyncAnalyzers" Version="1.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Cortside.MockServer.AccessControl" Version="1.3.30-develop" />
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.6.40">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="108.0.3" />
-    <PackageReference Include="WireMock.Net" Version="1.5.13" />
+    <PackageReference Include="WireMock.Net" Version="1.5.29" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Cortside.RestApiClient\Cortside.RestApiClient.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="appsettings.integration.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -46,5 +42,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/Cortside.RestApiClient.Tests/Cortside.RestApiClient.Tests.csproj
+++ b/src/Cortside.RestApiClient.Tests/Cortside.RestApiClient.Tests.csproj
@@ -9,10 +9,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Cortside.MockServer.AccessControl" Version="1.3.30-develop" />
+    <PackageReference Include="Cortside.MockServer.AccessControl" Version="6.0.39-develop" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.6.40">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -20,9 +20,9 @@
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="WireMock.Net" Version="1.5.29" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="WireMock.Net" Version="1.5.32" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Cortside.RestApiClient.Tests/Cortside.RestApiClient.Tests.csproj
+++ b/src/Cortside.RestApiClient.Tests/Cortside.RestApiClient.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <NoWarn>1701;1702;VSTHRD200;</NoWarn>
@@ -19,7 +19,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RestSharp" Version="108.0.3" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="WireMock.Net" Version="1.5.29" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Cortside.RestApiClient.Tests/GitHubClientTest.cs
+++ b/src/Cortside.RestApiClient.Tests/GitHubClientTest.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Cortside.RestApiClient.Tests.Clients.GitHubApi;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -7,12 +8,12 @@ using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Cortside.RestApiClient.Tests {
-    public class ClientTest {
+    public class GitHubClientTest {
         [Fact]
         public async Task ShouldGetRepositoriesDefaultCacheAsync() {
             // arrange
             var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
-            var client = new GitHubClient(new NullLogger<GitHubClient>(), cache);
+            var client = new GitHubClient(new NullLogger<GitHubClient>(), cache, new HttpContextAccessor());
 
             // act
             var repos = await client.GetReposAsync().ConfigureAwait(false);
@@ -27,7 +28,7 @@ namespace Cortside.RestApiClient.Tests {
         public async Task ShouldGetRepositoriesAsync() {
             // arrange
             var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
-            var client = new GitHubClient(new NullLogger<GitHubClient>(), cache);
+            var client = new GitHubClient(new NullLogger<GitHubClient>(), cache, new HttpContextAccessor());
 
             // act
             var repos = await client.GetReposAsync().ConfigureAwait(false);

--- a/src/Cortside.RestApiClient.Tests/Mocks/DelegationGrantMock.cs
+++ b/src/Cortside.RestApiClient.Tests/Mocks/DelegationGrantMock.cs
@@ -12,7 +12,7 @@ namespace Cortside.RestApiClient.Tests.Mocks {
                 .Given(
                     Request.Create()
                         .WithPath("/connect/token")
-                        .WithBody(b => b?.Contains("delegation") == true && b?.Contains("foo") == true)
+                        .WithBody(b => b?.Contains("grant_type=delegation") == true && b?.Contains("client_id=foo") == true)
                         .UsingPost()
                 )
                 .RespondWith(
@@ -22,7 +22,61 @@ namespace Cortside.RestApiClient.Tests.Mocks {
                         .WithBody(_ => JsonConvert.SerializeObject(new AuthenticationResponseModel {
                             TokenType = "Bearer",
                             ExpiresIn = "3600",
-                            AccessToken = "delegation-token"
+                            AccessToken = "foo-delegation-token"
+                        }))
+                );
+
+            server
+                .Given(
+                    Request.Create()
+                        .WithPath("/connect/token")
+                        .WithBody(b => b?.Contains("grant_type=client_credentials") == true && b?.Contains("client_id=foo") == true)
+                        .UsingPost()
+                )
+                .RespondWith(
+                    Response.Create()
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/json")
+                        .WithBody(_ => JsonConvert.SerializeObject(new AuthenticationResponseModel {
+                            TokenType = "Bearer",
+                            ExpiresIn = "3600",
+                            AccessToken = "foo-client_credentials-token"
+                        }))
+                );
+
+            server
+                .Given(
+                    Request.Create()
+                        .WithPath("/connect/token")
+                        .WithBody(b => b?.Contains("grant_type=delegation") == true && b?.Contains("client_id=allow") == true)
+                        .UsingPost()
+                )
+                .RespondWith(
+                    Response.Create()
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/json")
+                        .WithBody(_ => JsonConvert.SerializeObject(new AuthenticationResponseModel {
+                            TokenType = "Bearer",
+                            ExpiresIn = "3600",
+                            AccessToken = "allow-delegation-token"
+                        }))
+                );
+
+            server
+                .Given(
+                    Request.Create()
+                        .WithPath("/connect/token")
+                        .WithBody(b => b?.Contains("grant_type=client_credentials") == true && b?.Contains("client_id=allow") == true)
+                        .UsingPost()
+                )
+                .RespondWith(
+                    Response.Create()
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/json")
+                        .WithBody(_ => JsonConvert.SerializeObject(new AuthenticationResponseModel {
+                            TokenType = "Bearer",
+                            ExpiresIn = "3600",
+                            AccessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2OTA0ODIyNzEsImV4cCI6MTcyMjAxODI3MSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsImdyYW50X3R5cGUiOiJkZWxlZ2F0aW9uIn0.x43mQWtHy_ubj36gMXuoYtqp6K32w9XVuooYXWWVQNo"
                         }))
                 );
         }

--- a/src/Cortside.RestApiClient.Tests/Mocks/TestMock.cs
+++ b/src/Cortside.RestApiClient.Tests/Mocks/TestMock.cs
@@ -2,6 +2,7 @@
 using Cortside.MockServer;
 using Cortside.RestApiClient.Tests.Clients.CatalogApi;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -98,6 +99,20 @@ namespace Cortside.RestApiClient.Tests.Mocks {
                         .WithStatusCode(302)
                         .WithHeader("Content-Type", "application/json")
                         .WithHeader("Location", "/api/v1/temp302")
+                );
+
+            server
+                .Given(
+                    Request.Create().WithPath("/api/v1/jsonmodelmismatch")
+                        .UsingGet()
+                )
+                .RespondWith(
+                    Response.Create()
+                        .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/json")
+                        .WithBody(r => JsonConvert.SerializeObject(new JObject {
+                            ["ItemId"] = null
+                        }))
                 );
         }
     }

--- a/src/Cortside.RestApiClient.Tests/RetryTest.cs
+++ b/src/Cortside.RestApiClient.Tests/RetryTest.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Cortside.RestApiClient.Tests.Clients.HttpStatusApi;
 using Cortside.RestApiClient.Tests.ResponseProviders;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using WireMock.RequestBuilders;
 using WireMock.Server;
@@ -15,7 +16,7 @@ namespace Cortside.RestApiClient.Tests {
             _server.Given(Request.Create().WithPath("/200retry").UsingGet()).RespondWith(new AlternateFailureResponse());
             string url = "http://localhost:" + _server.Ports[0];
 
-            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), url);
+            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), url, new HttpContextAccessor());
 
             // act
             var repos = await client.Get200Async().ConfigureAwait(false);

--- a/src/Cortside.RestApiClient.Tests/SerializationTest.cs
+++ b/src/Cortside.RestApiClient.Tests/SerializationTest.cs
@@ -9,11 +9,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 namespace Cortside.RestApiClient.Tests {
-    public class SerilizationTest {
+    public class SerializationTest {
         private readonly CatalogClientConfiguration config;
         public static MockHttpServer Server { get; set; }
 
-        public SerilizationTest() {
+        public SerializationTest() {
             var name = Guid.NewGuid().ToString();
             Server = new MockHttpServer(name)
                 .ConfigureBuilder(new IdentityServerMock("./Data/discovery.json", "./Data/jwks.json"))
@@ -36,16 +36,16 @@ namespace Cortside.RestApiClient.Tests {
         }
 
         [Fact]
-        public async Task ShouldThrowExceptionOnSerilizationErrorAsync() {
+        public Task ShouldThrowExceptionOnSerializationErrorAsync() {
             // arrange
             var client = new CatalogClient(new NullLogger<HttpStatusClient>(), config, new HttpContextAccessor(), true);
 
             // act
-            await Assert.ThrowsAnyAsync<Exception>(async () => await client.ModelMismatchAsync().ConfigureAwait(false)).ConfigureAwait(false);
+            return Assert.ThrowsAnyAsync<Exception>(async () => await client.ModelMismatchAsync().ConfigureAwait(false));
         }
 
         [Fact]
-        public async Task ShouldFailOnSerilizationErrorAsync() {
+        public async Task ShouldFailOnSerializationErrorAsync() {
             // arrange
             var client = new CatalogClient(new NullLogger<HttpStatusClient>(), config, new HttpContextAccessor(), false);
 

--- a/src/Cortside.RestApiClient.Tests/SerializationTest.cs
+++ b/src/Cortside.RestApiClient.Tests/SerializationTest.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading.Tasks;
+using Cortside.MockServer;
+using Cortside.MockServer.AccessControl;
+using Cortside.RestApiClient.Tests.Clients.CatalogApi;
+using Cortside.RestApiClient.Tests.Clients.HttpStatusApi;
+using Cortside.RestApiClient.Tests.Mocks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+namespace Cortside.RestApiClient.Tests {
+    public class SerilizationTest {
+        private readonly CatalogClientConfiguration config;
+        public static MockHttpServer Server { get; set; }
+
+        public SerilizationTest() {
+            var name = Guid.NewGuid().ToString();
+            Server = new MockHttpServer(name)
+                .ConfigureBuilder(new IdentityServerMock("./Data/discovery.json", "./Data/jwks.json"))
+                .ConfigureBuilder(new SubjectMock("./Data/subjects.json"))
+                .ConfigureBuilder<TestMock>();
+
+            Server.WaitForStart();
+
+            config = new CatalogClientConfiguration() {
+                ServiceUrl = Server.Url,
+                Authentication = new Cortside.RestApiClient.Authenticators.OpenIDConnect.TokenRequest() {
+                    AuthorityUrl = Server.Url,
+                    ClientId = "foo",
+                    ClientSecret = "bar",
+                    GrantType = "client_credentials",
+                    Scope = "catalog-api",
+                    SlidingExpiration = 30
+                }
+            };
+        }
+
+        [Fact]
+        public async Task ShouldThrowExceptionOnSerilizationErrorAsync() {
+            // arrange
+            var client = new CatalogClient(new NullLogger<HttpStatusClient>(), config, new HttpContextAccessor(), true);
+
+            // act
+            await Assert.ThrowsAnyAsync<Exception>(async () => await client.ModelMismatchAsync().ConfigureAwait(false)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ShouldFailOnSerilizationErrorAsync() {
+            // arrange
+            var client = new CatalogClient(new NullLogger<HttpStatusClient>(), config, new HttpContextAccessor(), false);
+
+            // act
+            var response = await client.ModelMismatchAsync().ConfigureAwait(false);
+            Assert.NotNull(response.ErrorException);
+        }
+    }
+}

--- a/src/Cortside.RestApiClient.Tests/TimeoutTest.cs
+++ b/src/Cortside.RestApiClient.Tests/TimeoutTest.cs
@@ -4,6 +4,7 @@ using Cortside.MockServer;
 using Cortside.MockServer.AccessControl;
 using Cortside.RestApiClient.Tests.Clients.HttpStatusApi;
 using Cortside.RestApiClient.Tests.Mocks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using RestSharp;
 using Xunit;
@@ -29,7 +30,7 @@ namespace Cortside.RestApiClient.Tests {
                 BaseUrl = new Uri(Server.Url),
                 ThrowOnAnyError = true
             };
-            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), options);
+            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), new HttpContextAccessor(), options);
 
             // act
             return Assert.ThrowsAsync<TimeoutException>(() => client.GetTimeoutAsync());
@@ -42,7 +43,7 @@ namespace Cortside.RestApiClient.Tests {
                 BaseUrl = new Uri(Server.Url),
                 ThrowOnAnyError = false
             };
-            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), options);
+            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), new HttpContextAccessor(), options);
 
             // act
             return Assert.ThrowsAsync<TimeoutException>(() => client.GetTimeoutAsync());
@@ -55,7 +56,7 @@ namespace Cortside.RestApiClient.Tests {
                 BaseUrl = new Uri(Server.Url),
                 ThrowOnAnyError = true
             };
-            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), options);
+            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), new HttpContextAccessor(), options);
 
             // act
             RestResponse response = null;
@@ -70,7 +71,7 @@ namespace Cortside.RestApiClient.Tests {
                 BaseUrl = new Uri(Server.Url),
                 ThrowOnAnyError = false
             };
-            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), options);
+            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), new HttpContextAccessor(), options);
 
             // act
             RestResponse response = await client.ExecuteTimeoutAsync();

--- a/src/Cortside.RestApiClient.Tests/XmlTest.cs
+++ b/src/Cortside.RestApiClient.Tests/XmlTest.cs
@@ -4,6 +4,7 @@ using Cortside.MockServer;
 using Cortside.RestApiClient.Tests.Clients.HttpStatusApi;
 using Cortside.RestApiClient.Tests.Clients.LexisNexisApi;
 using Cortside.RestApiClient.Tests.Mocks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -30,7 +31,7 @@ namespace Cortside.RestApiClient.Tests {
         [Fact]
         public async Task ShouldGetItemAsync() {
             // arrange
-            var client = new LexisNexisClient(new NullLogger<HttpStatusClient>(), config);
+            var client = new LexisNexisClient(new NullLogger<HttpStatusClient>(), config, new HttpContextAccessor());
 
             // act
             var item = await client.InstantIdAsync().ConfigureAwait(false);

--- a/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
@@ -93,7 +93,7 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
                 var jwtToken = handler.ReadJwtToken(token);
                 return jwtToken.Claims.Any(x => x.Type == "grant_type" && x.Value == "delegation");
             } catch (Exception ex) {
-                logger.LogDebug(ex, "");
+                logger.LogDebug(ex, "Unable to read token as JWT token to figure out if token has grant_type claim for delegation");
                 return false;
             }
         }

--- a/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
@@ -17,7 +17,7 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
     public class OpenIDConnectAuthenticator : AuthenticatorBase {
         private readonly TokenRequest tokenRequest;
         private IAsyncPolicy<RestResponse> policy = Policy.NoOpAsync<RestResponse>();
-        private ILogger<OpenIDConnectAuthenticator> logger = new NullLogger<OpenIDConnectAuthenticator>();
+        private ILogger logger = new NullLogger<OpenIDConnectAuthenticator>();
         private readonly DateTime tokenExpiration = DateTime.UtcNow;
         private readonly IHttpContextAccessor context;
 
@@ -42,7 +42,7 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
             return this;
         }
 
-        public OpenIDConnectAuthenticator UseLogger(ILogger<OpenIDConnectAuthenticator> logger) {
+        public OpenIDConnectAuthenticator UseLogger(ILogger logger) {
             this.logger = logger;
             return this;
         }

--- a/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
@@ -101,9 +101,7 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
         private async Task<RestResponse<TokenResponse>> GetTokenAsync(string url, string grantType, string clientId, string clientSecret, string scope, string token = null) {
             var options = new RestClientOptions(url);
 
-            using (var client = new RestClient(options)) {
-                client.UseNewtonsoftJson();
-
+            using (var client = new RestClient(options, configureSerialization: s => s.UseNewtonsoftJson())) {
                 var request = new RestRequest("connect/token", Method.Post)
                     .AddParameter("grant_type", grantType)
                     .AddParameter("scope", scope)

--- a/src/Cortside.RestApiClient/Cortside.RestApiClient.csproj
+++ b/src/Cortside.RestApiClient/Cortside.RestApiClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
@@ -7,9 +7,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Cortside.Common.Correlation" Version="1.3.353" />
-    <PackageReference Include="Cortside.Common.Json" Version="1.3.353" />
-    <PackageReference Include="Cortside.Common.Validation" Version="1.3.353" />
+    <PackageReference Include="Cortside.Common.Correlation" Version="6.0.369-develop" />
+    <PackageReference Include="Cortside.Common.Json" Version="6.0.369-develop" />
+    <PackageReference Include="Cortside.Common.Validation" Version="6.0.369-develop" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.6.40">
@@ -22,6 +22,6 @@
     <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />
     <PackageReference Include="RestSharp.Serializers.Xml" Version="110.2.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.31.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.0" />
   </ItemGroup>
 </Project>

--- a/src/Cortside.RestApiClient/Cortside.RestApiClient.csproj
+++ b/src/Cortside.RestApiClient/Cortside.RestApiClient.csproj
@@ -7,12 +7,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Cortside.Common.Correlation" Version="6.0.369-develop" />
-    <PackageReference Include="Cortside.Common.Json" Version="6.0.369-develop" />
-    <PackageReference Include="Cortside.Common.Validation" Version="6.0.369-develop" />
+    <PackageReference Include="Cortside.Common.Correlation" Version="6.0.376" />
+    <PackageReference Include="Cortside.Common.Json" Version="6.0.376" />
+    <PackageReference Include="Cortside.Common.Validation" Version="6.0.376" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.6.40">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -22,6 +22,6 @@
     <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />
     <PackageReference Include="RestSharp.Serializers.Xml" Version="110.2.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.2" />
   </ItemGroup>
 </Project>

--- a/src/Cortside.RestApiClient/Cortside.RestApiClient.csproj
+++ b/src/Cortside.RestApiClient/Cortside.RestApiClient.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AsyncAnalyzers" Version="1.1.7">
       <PrivateAssets>all</PrivateAssets>
@@ -13,17 +11,16 @@
     <PackageReference Include="Cortside.Common.Json" Version="1.3.353" />
     <PackageReference Include="Cortside.Common.Validation" Version="1.3.353" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.6.40">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="RestSharp" Version="108.0.3" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="108.0.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.31.0" />
   </ItemGroup>
-
 </Project>

--- a/src/Cortside.RestApiClient/Cortside.RestApiClient.csproj
+++ b/src/Cortside.RestApiClient/Cortside.RestApiClient.csproj
@@ -19,8 +19,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageReference Include="RestSharp" Version="108.0.3" />
-    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="108.0.3" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />
+    <PackageReference Include="RestSharp.Serializers.Xml" Version="110.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.31.0" />
   </ItemGroup>
 </Project>

--- a/src/Cortside.RestApiClient/HttpContextUtility.cs
+++ b/src/Cortside.RestApiClient/HttpContextUtility.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Cortside.RestApiClient {
+    public static class HttpContextUtility {
+        public static string GetRequestIpAddress(HttpContext httpContext) {
+            string ipList = httpContext?.Request?.Headers["X-FORWARDED-FOR"].ToString();
+            if (!string.IsNullOrEmpty(ipList)) {
+                return ipList.Split(',')[0];
+            }
+
+            var ip = httpContext?.Connection?.RemoteIpAddress?.ToString();
+            if (httpContext!.Request?.Headers?.ContainsKey("REMOTE_ADDR") == true) {
+                ip = httpContext.Request.Headers["REMOTE_ADDR"].ToString();
+            }
+
+            return ip;
+        }
+    }
+}

--- a/src/Cortside.RestApiClient/JsonNetSerializer.cs
+++ b/src/Cortside.RestApiClient/JsonNetSerializer.cs
@@ -31,7 +31,7 @@ namespace Cortside.RestApiClient {
 
         public T Deserialize<T>(RestResponse response) => JsonConvert.DeserializeObject<T>(response.Content, settings);
 
-        public string ContentType { get; set; } = "application/json";
+        public ContentType ContentType { get; set; } = "application/json";
 
         public DataFormat DataFormat { get; } = DataFormat.Json;
 
@@ -39,10 +39,10 @@ namespace Cortside.RestApiClient {
 
         public IDeserializer Deserializer => this;
 
-        public string[] SupportedContentTypes => RestSharp.Serializers.ContentType.JsonAccept;
+        public string[] SupportedContentTypes => ContentType.JsonAccept;
 
-        public string[] AcceptedContentTypes => RestSharp.Serializers.ContentType.JsonAccept;
+        public string[] AcceptedContentTypes => ContentType.JsonAccept;
 
-        public SupportsContentType SupportsContentType => contentType => contentType.EndsWith("json", StringComparison.InvariantCultureIgnoreCase);
+        public SupportsContentType SupportsContentType => contentType => contentType.Value.EndsWith("json", StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/src/Cortside.RestApiClient/RestApiClient.cs
+++ b/src/Cortside.RestApiClient/RestApiClient.cs
@@ -6,6 +6,7 @@ using Cortside.Common.Correlation;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using RestSharp;
+using RestSharp.Serializers.Xml;
 using Serilog.Context;
 
 namespace Cortside.RestApiClient {
@@ -25,15 +26,11 @@ namespace Cortside.RestApiClient {
             this.logger = logger;
             this.options = options;
 
-            client = new RestClient(options.Options);
-            if (options.Authenticator != null) {
-                client.UseAuthenticator(options.Authenticator);
-            }
             if (options.Serializer != null) {
-                client.UseSerializer(() => options.Serializer);
+                client = new RestClient(options.Options, configureSerialization: s => s.UseSerializer(() => options.Serializer));
             }
             if (options.XmlSerializer) {
-                client.UseXml();
+                client = new RestClient(options.Options, configureSerialization: s => s.UseXmlSerializer());
             }
         }
 

--- a/src/Cortside.RestApiClient/RestApiClient.cs
+++ b/src/Cortside.RestApiClient/RestApiClient.cs
@@ -132,7 +132,15 @@ namespace Cortside.RestApiClient {
 
         public async Task<RestResponse<T>> ExecuteAsync<T>(IRestApiRequest request) {
             var response = await InnerExecuteAsync(request).ConfigureAwait(false);
-            return client.Deserialize<T>(response);
+            var result = client.Deserialize<T>(response);
+
+            var ex = result.ErrorException;
+            if ((options.ThrowOnDeserializationError || options.ThrowOnAnyError) && ex != null) {
+                LogError(request, result);
+                throw ex;
+            }
+
+            return result;
         }
 
         public async Task<RestResponse> GetAsync(IRestApiRequest request) {
@@ -160,7 +168,7 @@ namespace Cortside.RestApiClient {
                 return response;
             } else {
                 LogError(request, response);
-                throw new RestApiException("unsucessful request--need better message");
+                throw new RestApiException("unsuccessful request--need better message");
             }
         }
 

--- a/src/Cortside.RestApiClient/RestApiClient.cs
+++ b/src/Cortside.RestApiClient/RestApiClient.cs
@@ -17,13 +17,14 @@ namespace Cortside.RestApiClient {
         private readonly RestApiClientOptions options;
         private readonly IHttpContextAccessor contextAccessor;
 
-        public RestApiClient(ILogger logger, string baseUrl) {
-            this.logger = logger;
-
-            options = new RestApiClientOptions(baseUrl);
-            client = new RestClient(options.Options);
+        [Obsolete("Use overload that takes IHttpContextAccessor")]
+        public RestApiClient(ILogger logger, string baseUrl) : this(logger, new HttpContextAccessor(), baseUrl) {
         }
 
+        public RestApiClient(ILogger logger, IHttpContextAccessor contextAccessor, string baseUrl) : this(logger, contextAccessor, new RestApiClientOptions(baseUrl)) {
+        }
+
+        [Obsolete("Use overload that takes IHttpContextAccessor")]
         public RestApiClient(ILogger logger, RestApiClientOptions options) : this(logger, new HttpContextAccessor(), options) {
         }
 

--- a/src/Cortside.RestApiClient/RestApiClient.cs
+++ b/src/Cortside.RestApiClient/RestApiClient.cs
@@ -117,6 +117,10 @@ namespace Cortside.RestApiClient {
             }
 
             var ip = HttpContextUtility.GetRequestIpAddress(contextAccessor.HttpContext);
+            if (string.IsNullOrWhiteSpace(ip)) {
+                return;
+            }
+
             request.AddHeader("X-Forwarded-For", ip);
             request.AddHeader("Forwarded", $"for={ip}");
         }

--- a/src/Cortside.RestApiClient/RestApiClientOptions.cs
+++ b/src/Cortside.RestApiClient/RestApiClientOptions.cs
@@ -60,7 +60,10 @@ namespace Cortside.RestApiClient {
 
         public bool FollowRedirects { get; set; } = false;
 
-        public IAuthenticator Authenticator { get; set; }
+        public IAuthenticator Authenticator {
+            get { return rcOptions.Authenticator; }
+            set { rcOptions.Authenticator = value; }
+        }
 
         public IRestSerializer Serializer { get; set; }
 

--- a/src/Cortside.RestApiClient/RestApiRequest.cs
+++ b/src/Cortside.RestApiClient/RestApiRequest.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Net.Http;
 using Polly;
 using RestSharp;
-using RestSharp.Serializers;
 
 namespace Cortside.RestApiClient {
     public class RestApiRequest : IRestApiRequest {
@@ -133,7 +132,7 @@ namespace Cortside.RestApiClient {
         }
 
         public RestApiRequest AddStringBody(string body, DataFormat dataFormat) {
-            string contentType = ContentType.FromDataFormat[dataFormat];
+            ContentType contentType = ContentType.FromDataFormat(dataFormat);
             request.RequestFormat = dataFormat;
             request.AddParameter(new BodyParameter("", body, contentType));
             return this;
@@ -146,7 +145,7 @@ namespace Cortside.RestApiClient {
 
         public RestApiRequest AddJsonBody<T>(T obj, string contentType = "application/json") where T : class {
             request.RequestFormat = DataFormat.Json;
-            if (!(obj is string text)) {
+            if (obj is not string text) {
                 request.AddParameter(new JsonParameter("", obj, contentType));
                 return this;
             }
@@ -157,7 +156,7 @@ namespace Cortside.RestApiClient {
 
         public RestApiRequest AddXmlBody<T>(T obj, string contentType = "application/xml", string xmlNamespace = "") where T : class {
             request.RequestFormat = DataFormat.Xml;
-            if (!(obj is string text)) {
+            if (obj is not string text) {
                 request.AddParameter(new XmlParameter("", obj, xmlNamespace, contentType));
                 return this;
             }


### PR DESCRIPTION
# Release 6.0

* Update version number to match framework version (6.x)
* Update projects to be net6.0
* Update nuget dependencies to latest stable versions
* Update to latest RestSharp and handle breaking changes
* Set X-Forwarded-For header on client requests that originated from httprequest to capture original client ip
* Improved authenticator logging
* Handle deserialization exception when throw is true

|Commit|Date|Author|Message|
|---|---|---|---|
| 6fb4e8b | <span style="white-space:nowrap;">2023-06-15</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  update version
| c28b6e9 | <span style="white-space:nowrap;">2023-06-20</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  Merge branch 'master' into develop
| 1400841 | <span style="white-space:nowrap;">2023-06-23</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  [net6] update to net6
| bb7b232 | <span style="white-space:nowrap;">2023-06-23</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  [net6] update to latest restsharp library
| d9744b8 | <span style="white-space:nowrap;">2023-06-23</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  [net6] use vs2022 builder image
| 5e0f21b | <span style="white-space:nowrap;">2023-06-23</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  (origin/net6, net6) [net6] add useful message to when token parsing is not successful
| 4c336fd | <span style="white-space:nowrap;">2023-06-23</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  Merge pull request #15 from cortside/net6
| 541bc53 | <span style="white-space:nowrap;">2023-07-17</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  update version to 6.x to be in line with dotnet and net6 version numbers
| 65ac8c9 | <span style="white-space:nowrap;">2023-07-17</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  update version to 6.x to be in line with dotnet and net6 version numbers
| 85bbf9c | <span style="white-space:nowrap;">2023-07-25</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  set X-Forwarded-For header on client requests that originated from httprequest to capture original client ip
| 7a47485 | <span style="white-space:nowrap;">2023-07-26</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  set X-Forwarded-For header on client requests that originated from httprequest to capture original client ip
| 35d06d0 | <span style="white-space:nowrap;">2023-07-26</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  set X-Forwarded-For header on client requests that originated from httprequest to capture original client ip
| d96fafe | <span style="white-space:nowrap;">2023-07-26</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  allow for any ILogger in authenticator
| d66d8a4 | <span style="white-space:nowrap;">2023-07-27</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  add more tests for delegation and better validation if there is reason to attempt to delegate
| 346d497 | <span style="white-space:nowrap;">2023-08-15</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  [OR-2315] handle deserialization exception when throw is true
| 82eaaea | <span style="white-space:nowrap;">2023-08-15</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  (origin/OR-2315, OR-2315) nudge for build
| 5a21159 | <span style="white-space:nowrap;">2023-08-29</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  Merge pull request #16 from cortside/OR-2315
| ecbcdd4 | <span style="white-space:nowrap;">2023-08-30</span> | <span style="white-space:nowrap;">Cort Schaefer</span> |  (HEAD -> release/6.0, origin/develop, origin/HEAD, develop) update to latest nuget packages
****