### PR TITLE
[SVC-2887] support for authenticator to clear token on 401 response

### DIFF
--- a/src/Cortside.RestApiClient.Tests/Clients/TestAuthenticator.cs
+++ b/src/Cortside.RestApiClient.Tests/Clients/TestAuthenticator.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using Cortside.RestApiClient.Authenticators;
+using RestSharp;
+
+namespace Cortside.RestApiClient.Tests.Clients {
+    public class TestAuthenticator : RestApiAuthenticator {
+        public TestAuthenticator() : base(String.Empty) {
+        }
+
+        protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken) {
+            if (string.IsNullOrEmpty(Token)) {
+                Token = Guid.NewGuid().ToString();
+            }
+
+            return new HeaderParameter(KnownHeaders.Authorization, Token);
+        }
+
+        public override void HandleUnauthorizedClientRequest() {
+            Token = null;
+        }
+
+        public string CachedToken => Token;
+    }
+}

--- a/src/Cortside.RestApiClient.Tests/Clients/TestAuthenticator.cs
+++ b/src/Cortside.RestApiClient.Tests/Clients/TestAuthenticator.cs
@@ -5,19 +5,24 @@ using RestSharp;
 
 namespace Cortside.RestApiClient.Tests.Clients {
     public class TestAuthenticator : RestApiAuthenticator {
-        public TestAuthenticator() : base(String.Empty) {
-        }
+        private DateTime expirationDate;
+
+        public TestAuthenticator() : base(String.Empty) { }
 
         protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken) {
-            if (string.IsNullOrEmpty(Token)) {
+            if (string.IsNullOrEmpty(Token) || expirationDate >= DateTime.UtcNow) {
                 Token = Guid.NewGuid().ToString();
+                expirationDate = DateTime.UtcNow.AddDays(1);
             }
 
             return new HeaderParameter(KnownHeaders.Authorization, Token);
         }
 
         public override void HandleUnauthorizedClientRequest() {
-            Token = null;
+            // do other things here that might be needed outside of what base does
+            expirationDate = DateTime.MinValue;
+
+            base.HandleUnauthorizedClientRequest();
         }
 
         public string CachedToken => Token;

--- a/src/Cortside.RestApiClient.Tests/Cortside.RestApiClient.Tests.csproj
+++ b/src/Cortside.RestApiClient.Tests/Cortside.RestApiClient.Tests.csproj
@@ -9,26 +9,26 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cortside.Common.Testing" Version="6.2.403" />
+    <PackageReference Include="Cortside.Common.Testing" Version="6.2.408" />
     <PackageReference Include="Cortside.MockServer.AccessControl" Version="6.1.62" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="HttpTracer" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.8.14">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="WireMock.Net" Version="1.5.46" />
-    <PackageReference Include="xunit" Version="2.6.5" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="WireMock.Net" Version="1.5.49" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Cortside.RestApiClient.Tests/RetryTest.cs
+++ b/src/Cortside.RestApiClient.Tests/RetryTest.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Threading.Tasks;
+using Cortside.RestApiClient.Tests.Clients;
 using Cortside.RestApiClient.Tests.Clients.HttpStatusApi;
 using Cortside.RestApiClient.Tests.ResponseProviders;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
 using WireMock.Server;
 using Xunit;
 
@@ -12,17 +15,63 @@ namespace Cortside.RestApiClient.Tests {
         [Fact]
         public async Task ShouldRetryAsync() {
             // arrange
-            var _server = WireMockServer.Start();
-            _server.Given(Request.Create().WithPath("/200retry").UsingGet()).RespondWith(new AlternateFailureResponse());
-            string url = "http://localhost:" + _server.Ports[0];
+            var server = WireMockServer.Start();
+            server.Given(Request.Create().WithPath("/200retry").UsingGet()).RespondWith(new AlternateFailureResponse());
+
+            string url = "http://localhost:" + server.Ports[0];
 
             var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), url, new HttpContextAccessor());
 
             // act
-            var repos = await client.Get200Async();
+            var repos = await client.Get200RetryAsync();
 
             // assert
             Assert.NotEmpty(repos);
         }
+
+        [Fact]
+        public async Task ShouldReauthenticateAsync() {
+            // arrange
+            var server = WireMockServer.Start();
+            server.Given(Request.Create().WithPath("/401").UsingGet()).RespondWith(Response.Create().WithStatusCode(401));
+            string url = "http://localhost:" + server.Ports[0];
+
+            var authenticator = new TestAuthenticator();
+            var options = new RestApiClientOptions() {
+                BaseUrl = new Uri(url),
+                Authenticator = authenticator
+            };
+            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), new HttpContextAccessor(), options);
+
+            // act
+            var response = await client.Get401Async();
+
+            // assert
+            Assert.False(response.IsSuccessful);
+            Assert.Null(authenticator.CachedToken);
+        }
+
+        [Fact]
+        public async Task ShouldNotReauthenticateAsync() {
+            // arrange
+            var server = WireMockServer.Start();
+            server.Given(Request.Create().WithPath("/200").UsingGet()).RespondWith(Response.Create().WithStatusCode(200));
+            string url = "http://localhost:" + server.Ports[0];
+
+            var authenticator = new TestAuthenticator();
+            var options = new RestApiClientOptions() {
+                BaseUrl = new Uri(url),
+                Authenticator = authenticator
+            };
+            var client = new HttpStatusClient(new NullLogger<HttpStatusClient>(), new HttpContextAccessor(), options);
+
+            // act
+            var response = await client.Get200Async();
+
+            // assert
+            Assert.True(response.IsSuccessful);
+            Assert.NotNull(authenticator.CachedToken);
+        }
+
     }
 }

--- a/src/Cortside.RestApiClient/Authenticators/IRestApiAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/IRestApiAuthenticator.cs
@@ -1,0 +1,7 @@
+﻿using RestSharp.Authenticators;
+
+namespace Cortside.RestApiClient.Authenticators {
+    public interface IRestApiAuthenticator : IAuthenticator {
+        void ClearToken();
+    }
+}

--- a/src/Cortside.RestApiClient/Authenticators/IRestApiAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/IRestApiAuthenticator.cs
@@ -2,6 +2,11 @@
 
 namespace Cortside.RestApiClient.Authenticators {
     public interface IRestApiAuthenticator : IAuthenticator {
-        void ClearToken();
+        /// <summary>
+        /// Resets the cached authorization token to force reauthorization.  This is used by RestApiClient
+        /// in the case of authorization failure (401) in cases like revoked tokens.
+        /// Override this method to do something other than just set the internal token to null.
+        /// </summary>
+        void ResetToken();
     }
 }

--- a/src/Cortside.RestApiClient/Authenticators/IRestApiAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/IRestApiAuthenticator.cs
@@ -7,6 +7,6 @@ namespace Cortside.RestApiClient.Authenticators {
         /// in the case of authorization failure (401) in cases like revoked tokens.
         /// Override this method to do something other than just set the internal token to null.
         /// </summary>
-        void ResetToken();
+        void HandleUnauthorizedClientRequest();
     }
 }

--- a/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
@@ -1,5 +1,3 @@
-#pragma warning disable _MissingAsync // TAP methods must end with Async.
-
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
@@ -11,13 +9,10 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Polly;
 using RestSharp;
-using RestSharp.Authenticators;
 using RestSharp.Serializers.NewtonsoftJson;
 
-namespace Cortside.RestApiClient.Authenticators.OpenIDConnect
-{
-    public class OpenIDConnectAuthenticator : AuthenticatorBase, IRestApiAuthenticator
-    {
+namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
+    public class OpenIDConnectAuthenticator : RestApiAuthenticator {
         private readonly TokenRequest tokenRequest;
         private IAsyncPolicy<RestResponse> policy = Policy.NoOpAsync<RestResponse>();
         private ILogger logger = new NullLogger<OpenIDConnectAuthenticator>();
@@ -25,17 +20,14 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect
         private readonly IHttpContextAccessor context;
         private bool clientAllowsDelegation = false;
 
-        public OpenIDConnectAuthenticator(IHttpContextAccessor context, TokenRequest tokenRequest) : base("")
-        {
+        public OpenIDConnectAuthenticator(IHttpContextAccessor context, TokenRequest tokenRequest) : base("") {
             this.context = context;
             this.tokenRequest = tokenRequest;
         }
 
-        public OpenIDConnectAuthenticator(IHttpContextAccessor context, string authorityUrl, string grantType, string clientId, string clientSecret, string scope) : base("")
-        {
+        public OpenIDConnectAuthenticator(IHttpContextAccessor context, string authorityUrl, string grantType, string clientId, string clientSecret, string scope) : base("") {
             this.context = context;
-            tokenRequest = new TokenRequest
-            {
+            tokenRequest = new TokenRequest {
                 AuthorityUrl = authorityUrl,
                 GrantType = grantType,
                 Scope = scope,
@@ -44,20 +36,17 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect
             };
         }
 
-        public OpenIDConnectAuthenticator UsePolicy(IAsyncPolicy<RestResponse> policy)
-        {
+        public OpenIDConnectAuthenticator UsePolicy(IAsyncPolicy<RestResponse> policy) {
             this.policy = policy;
             return this;
         }
 
-        public OpenIDConnectAuthenticator UseLogger(ILogger logger)
-        {
+        public OpenIDConnectAuthenticator UseLogger(ILogger logger) {
             this.logger = logger;
             return this;
         }
 
-        protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
-        {
+        protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken) {
             // will only show first 20 characters of header/token for security
             logger.LogTrace("GetAuthenticationParameter called with token {accessToken}. Token has cached value of {token} with expiration of {expiration}", accessToken.Left(20), Token.Left(20), tokenExpiration);
 
@@ -65,11 +54,9 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect
             var currentToken = Token;
 
             // get a new token if the cached one is not set OR it's expired
-            if (string.IsNullOrEmpty(Token) || tokenExpiration <= DateTime.UtcNow)
-            {
+            if (string.IsNullOrEmpty(Token) || tokenExpiration <= DateTime.UtcNow) {
                 var response = await GetTokenAsync(tokenRequest.AuthorityUrl, tokenRequest.GrantType, tokenRequest.ClientId, tokenRequest.ClientSecret, tokenRequest.Scope).ConfigureAwait(false);
-                if (!response.IsSuccessful || response.Data == null)
-                {
+                if (!response.IsSuccessful || response.Data == null) {
                     throw new AuthenticationException(response.ErrorMessage);
                 }
 
@@ -79,23 +66,19 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect
                 tokenExpiration = response.Data.ExpirationDate;
                 clientAllowsDelegation = AllowsDelegation(currentToken);
 
-                if (clientAllowsDelegation)
-                {
+                if (clientAllowsDelegation) {
                     logger.LogInformation($"Token for client_id {tokenRequest.ClientId} allows delegation");
                 }
             }
 
             // check to see if delegation is allowed and if there is an Authorization header from HttpContext
-            if (clientAllowsDelegation)
-            {
+            if (clientAllowsDelegation) {
                 var authorization = context?.HttpContext?.Request.Headers["Authorization"].ToString();
-                if (!string.IsNullOrWhiteSpace(authorization))
-                {
+                if (!string.IsNullOrWhiteSpace(authorization)) {
                     logger.LogInformation($"Delegation is allowed and Authorization header was found in HttpContext with value of {authorization.Left(20)}");
                     authorization = authorization.Replace("Bearer ", "");
                     var response = await GetTokenAsync(tokenRequest.AuthorityUrl, "delegation", tokenRequest.ClientId, tokenRequest.ClientSecret, tokenRequest.Scope, authorization).ConfigureAwait(false);
-                    if (!response.IsSuccessful || response.Data == null)
-                    {
+                    if (!response.IsSuccessful || response.Data == null) {
                         logger.LogWarning("Delegation token request failed, falling back to client token");
                     }
 
@@ -108,15 +91,12 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect
             return new HeaderParameter(KnownHeaders.Authorization, currentToken);
         }
 
-        private bool AllowsDelegation(string token)
-        {
-            if (string.IsNullOrWhiteSpace(token))
-            {
+        private bool AllowsDelegation(string token) {
+            if (string.IsNullOrWhiteSpace(token)) {
                 return false;
             }
 
-            try
-            {
+            try {
                 var handler = new JwtSecurityTokenHandler();
                 var jwtToken = handler.ReadJwtToken(token.Replace("Bearer ", ""));
                 var delegation = jwtToken.Claims.Any(x => x.Type == "grant_type" && x.Value == "delegation");
@@ -125,20 +105,16 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect
 
                 //return delegation && !self;
                 return delegation;
-            }
-            catch (Exception ex)
-            {
+            } catch (Exception ex) {
                 logger.LogDebug(ex, "Unable to read token as JWT token to figure out if token has grant_type claim for delegation");
                 return false;
             }
         }
 
-        private async Task<RestResponse<TokenResponse>> GetTokenAsync(string authorityUrl, string grantType, string clientId, string clientSecret, string scope, string token = null)
-        {
+        private async Task<RestResponse<TokenResponse>> GetTokenAsync(string authorityUrl, string grantType, string clientId, string clientSecret, string scope, string token = null) {
             var options = new RestClientOptions(authorityUrl);
 
-            using (var client = new RestClient(options, configureSerialization: s => s.UseNewtonsoftJson()))
-            {
+            using (var client = new RestClient(options, configureSerialization: s => s.UseNewtonsoftJson())) {
                 var request = new RestRequest("connect/token", Method.Post)
                     .AddParameter("grant_type", grantType)
                     .AddParameter("scope", scope)
@@ -151,34 +127,29 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect
                 request.AddHeader("X-Correlation-Id", correlationId);
 
                 logger.LogInformation($"Getting {grantType} token for client_id {clientId} with scopes [{scope}]");
-                var response = await policy.ExecuteAsync(async () =>
-                {
+                var response = await policy.ExecuteAsync(async () => {
                     var response = await client.ExecuteAsync<TokenResponse>(request).ConfigureAwait(false);
                     logger.LogInformation($"Identity Server response code: {response?.StatusCode}");
                     return response;
                 }).ConfigureAwait(false);
 
-                if (response.IsSuccessful)
-                {
+                if (response.IsSuccessful) {
                     // TODO: handling of deserialization exception?
                     // https://github.com/restsharp/RestSharp/blob/5830af48cf85b8eaadf89d83fbc3bf46106f5873/src/RestSharp/Serializers/DeseralizationException.cs
                     var rr = client.Deserialize<TokenResponse>(response);
                     logger.LogDebug($"Successfully obtained {grantType} token for client_id {clientId} with scopes [{scope}]");
 
                     return rr;
-                }
-                else
-                {
+                } else {
                     logger.LogError(response.ErrorException, $"Failed to obtain {grantType} token for client_id {clientId} with scopes [{scope}], Identity Server responded with status: {response.StatusCode} and error {response.ErrorMessage}");
                     return RestResponse<TokenResponse>.FromResponse(response);
                 }
             }
         }
 
-        public void ResetToken()
-        {
-            this.Token = null;
-            this.tokenExpiration = DateTime.MinValue;
+        public override void HandleUnauthorizedClientRequest() {
+            Token = null;
+            tokenExpiration = DateTime.MinValue;
         }
     }
 }

--- a/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
@@ -15,7 +15,7 @@ using RestSharp.Authenticators;
 using RestSharp.Serializers.NewtonsoftJson;
 
 namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
-    public class OpenIDConnectAuthenticator : AuthenticatorBase {
+    public class OpenIDConnectAuthenticator : AuthenticatorBase, IRestApiAuthenticator {
         private readonly TokenRequest tokenRequest;
         private IAsyncPolicy<RestResponse> policy = Policy.NoOpAsync<RestResponse>();
         private ILogger logger = new NullLogger<OpenIDConnectAuthenticator>();
@@ -148,6 +148,11 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
                     return RestResponse<TokenResponse>.FromResponse(response);
                 }
             }
+        }
+
+        public void ClearToken() {
+            this.Token = null;
+            this.tokenExpiration = DateTime.MinValue;
         }
     }
 }

--- a/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/OpenIDConnect/OpenIDConnectAuthenticator.cs
@@ -14,8 +14,10 @@ using RestSharp;
 using RestSharp.Authenticators;
 using RestSharp.Serializers.NewtonsoftJson;
 
-namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
-    public class OpenIDConnectAuthenticator : AuthenticatorBase, IRestApiAuthenticator {
+namespace Cortside.RestApiClient.Authenticators.OpenIDConnect
+{
+    public class OpenIDConnectAuthenticator : AuthenticatorBase, IRestApiAuthenticator
+    {
         private readonly TokenRequest tokenRequest;
         private IAsyncPolicy<RestResponse> policy = Policy.NoOpAsync<RestResponse>();
         private ILogger logger = new NullLogger<OpenIDConnectAuthenticator>();
@@ -23,14 +25,17 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
         private readonly IHttpContextAccessor context;
         private bool clientAllowsDelegation = false;
 
-        public OpenIDConnectAuthenticator(IHttpContextAccessor context, TokenRequest tokenRequest) : base("") {
+        public OpenIDConnectAuthenticator(IHttpContextAccessor context, TokenRequest tokenRequest) : base("")
+        {
             this.context = context;
             this.tokenRequest = tokenRequest;
         }
 
-        public OpenIDConnectAuthenticator(IHttpContextAccessor context, string authorityUrl, string grantType, string clientId, string clientSecret, string scope) : base("") {
+        public OpenIDConnectAuthenticator(IHttpContextAccessor context, string authorityUrl, string grantType, string clientId, string clientSecret, string scope) : base("")
+        {
             this.context = context;
-            tokenRequest = new TokenRequest {
+            tokenRequest = new TokenRequest
+            {
                 AuthorityUrl = authorityUrl,
                 GrantType = grantType,
                 Scope = scope,
@@ -39,17 +44,20 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
             };
         }
 
-        public OpenIDConnectAuthenticator UsePolicy(IAsyncPolicy<RestResponse> policy) {
+        public OpenIDConnectAuthenticator UsePolicy(IAsyncPolicy<RestResponse> policy)
+        {
             this.policy = policy;
             return this;
         }
 
-        public OpenIDConnectAuthenticator UseLogger(ILogger logger) {
+        public OpenIDConnectAuthenticator UseLogger(ILogger logger)
+        {
             this.logger = logger;
             return this;
         }
 
-        protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken) {
+        protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
+        {
             // will only show first 20 characters of header/token for security
             logger.LogTrace("GetAuthenticationParameter called with token {accessToken}. Token has cached value of {token} with expiration of {expiration}", accessToken.Left(20), Token.Left(20), tokenExpiration);
 
@@ -57,9 +65,11 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
             var currentToken = Token;
 
             // get a new token if the cached one is not set OR it's expired
-            if (string.IsNullOrEmpty(Token) || tokenExpiration <= DateTime.UtcNow) {
+            if (string.IsNullOrEmpty(Token) || tokenExpiration <= DateTime.UtcNow)
+            {
                 var response = await GetTokenAsync(tokenRequest.AuthorityUrl, tokenRequest.GrantType, tokenRequest.ClientId, tokenRequest.ClientSecret, tokenRequest.Scope).ConfigureAwait(false);
-                if (!response.IsSuccessful || response.Data == null) {
+                if (!response.IsSuccessful || response.Data == null)
+                {
                     throw new AuthenticationException(response.ErrorMessage);
                 }
 
@@ -69,19 +79,23 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
                 tokenExpiration = response.Data.ExpirationDate;
                 clientAllowsDelegation = AllowsDelegation(currentToken);
 
-                if (clientAllowsDelegation) {
+                if (clientAllowsDelegation)
+                {
                     logger.LogInformation($"Token for client_id {tokenRequest.ClientId} allows delegation");
                 }
             }
 
             // check to see if delegation is allowed and if there is an Authorization header from HttpContext
-            if (clientAllowsDelegation) {
+            if (clientAllowsDelegation)
+            {
                 var authorization = context?.HttpContext?.Request.Headers["Authorization"].ToString();
-                if (!string.IsNullOrWhiteSpace(authorization)) {
+                if (!string.IsNullOrWhiteSpace(authorization))
+                {
                     logger.LogInformation($"Delegation is allowed and Authorization header was found in HttpContext with value of {authorization.Left(20)}");
                     authorization = authorization.Replace("Bearer ", "");
                     var response = await GetTokenAsync(tokenRequest.AuthorityUrl, "delegation", tokenRequest.ClientId, tokenRequest.ClientSecret, tokenRequest.Scope, authorization).ConfigureAwait(false);
-                    if (!response.IsSuccessful || response.Data == null) {
+                    if (!response.IsSuccessful || response.Data == null)
+                    {
                         logger.LogWarning("Delegation token request failed, falling back to client token");
                     }
 
@@ -94,12 +108,15 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
             return new HeaderParameter(KnownHeaders.Authorization, currentToken);
         }
 
-        private bool AllowsDelegation(string token) {
-            if (string.IsNullOrWhiteSpace(token)) {
+        private bool AllowsDelegation(string token)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
                 return false;
             }
 
-            try {
+            try
+            {
                 var handler = new JwtSecurityTokenHandler();
                 var jwtToken = handler.ReadJwtToken(token.Replace("Bearer ", ""));
                 var delegation = jwtToken.Claims.Any(x => x.Type == "grant_type" && x.Value == "delegation");
@@ -108,16 +125,20 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
 
                 //return delegation && !self;
                 return delegation;
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 logger.LogDebug(ex, "Unable to read token as JWT token to figure out if token has grant_type claim for delegation");
                 return false;
             }
         }
 
-        private async Task<RestResponse<TokenResponse>> GetTokenAsync(string authorityUrl, string grantType, string clientId, string clientSecret, string scope, string token = null) {
+        private async Task<RestResponse<TokenResponse>> GetTokenAsync(string authorityUrl, string grantType, string clientId, string clientSecret, string scope, string token = null)
+        {
             var options = new RestClientOptions(authorityUrl);
 
-            using (var client = new RestClient(options, configureSerialization: s => s.UseNewtonsoftJson())) {
+            using (var client = new RestClient(options, configureSerialization: s => s.UseNewtonsoftJson()))
+            {
                 var request = new RestRequest("connect/token", Method.Post)
                     .AddParameter("grant_type", grantType)
                     .AddParameter("scope", scope)
@@ -130,27 +151,32 @@ namespace Cortside.RestApiClient.Authenticators.OpenIDConnect {
                 request.AddHeader("X-Correlation-Id", correlationId);
 
                 logger.LogInformation($"Getting {grantType} token for client_id {clientId} with scopes [{scope}]");
-                var response = await policy.ExecuteAsync(async () => {
+                var response = await policy.ExecuteAsync(async () =>
+                {
                     var response = await client.ExecuteAsync<TokenResponse>(request).ConfigureAwait(false);
                     logger.LogInformation($"Identity Server response code: {response?.StatusCode}");
                     return response;
                 }).ConfigureAwait(false);
 
-                if (response.IsSuccessful) {
+                if (response.IsSuccessful)
+                {
                     // TODO: handling of deserialization exception?
                     // https://github.com/restsharp/RestSharp/blob/5830af48cf85b8eaadf89d83fbc3bf46106f5873/src/RestSharp/Serializers/DeseralizationException.cs
                     var rr = client.Deserialize<TokenResponse>(response);
                     logger.LogDebug($"Successfully obtained {grantType} token for client_id {clientId} with scopes [{scope}]");
 
                     return rr;
-                } else {
+                }
+                else
+                {
                     logger.LogError(response.ErrorException, $"Failed to obtain {grantType} token for client_id {clientId} with scopes [{scope}], Identity Server responded with status: {response.StatusCode} and error {response.ErrorMessage}");
                     return RestResponse<TokenResponse>.FromResponse(response);
                 }
             }
         }
 
-        public void ClearToken() {
+        public void ResetToken()
+        {
             this.Token = null;
             this.tokenExpiration = DateTime.MinValue;
         }

--- a/src/Cortside.RestApiClient/Authenticators/RestApiAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/RestApiAuthenticator.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using RestSharp;
+
+namespace Cortside.RestApiClient.Authenticators {
+    public abstract class RestApiAuthenticator : IRestApiAuthenticator {
+        protected RestApiAuthenticator(string token) => Token = token;
+
+        protected string Token { get; set; }
+
+        protected abstract ValueTask<Parameter> GetAuthenticationParameter(string accessToken);
+
+        public async ValueTask Authenticate(IRestClient client, RestRequest request)
+            => request.AddOrUpdateParameter(await GetAuthenticationParameter(Token).ConfigureAwait(false));
+
+        public virtual void ClearToken() {
+            Token = null;
+        }
+    }
+}

--- a/src/Cortside.RestApiClient/Authenticators/RestApiAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/RestApiAuthenticator.cs
@@ -1,10 +1,8 @@
 ﻿using System.Threading.Tasks;
 using RestSharp;
 
-namespace Cortside.RestApiClient.Authenticators
-{
-    public abstract class RestApiAuthenticator : IRestApiAuthenticator
-    {
+namespace Cortside.RestApiClient.Authenticators {
+    public abstract class RestApiAuthenticator : IRestApiAuthenticator {
         protected RestApiAuthenticator(string token) => Token = token;
 
         protected string Token { get; set; }
@@ -14,8 +12,7 @@ namespace Cortside.RestApiClient.Authenticators
         public async ValueTask Authenticate(IRestClient client, RestRequest request)
             => request.AddOrUpdateParameter(await GetAuthenticationParameter(Token).ConfigureAwait(false));
 
-        public virtual void ResetToken()
-        {
+        public virtual void HandleUnauthorizedClientRequest() {
             Token = null;
         }
     }

--- a/src/Cortside.RestApiClient/Authenticators/RestApiAuthenticator.cs
+++ b/src/Cortside.RestApiClient/Authenticators/RestApiAuthenticator.cs
@@ -1,8 +1,10 @@
 ﻿using System.Threading.Tasks;
 using RestSharp;
 
-namespace Cortside.RestApiClient.Authenticators {
-    public abstract class RestApiAuthenticator : IRestApiAuthenticator {
+namespace Cortside.RestApiClient.Authenticators
+{
+    public abstract class RestApiAuthenticator : IRestApiAuthenticator
+    {
         protected RestApiAuthenticator(string token) => Token = token;
 
         protected string Token { get; set; }
@@ -12,7 +14,8 @@ namespace Cortside.RestApiClient.Authenticators {
         public async ValueTask Authenticate(IRestClient client, RestRequest request)
             => request.AddOrUpdateParameter(await GetAuthenticationParameter(Token).ConfigureAwait(false));
 
-        public virtual void ClearToken() {
+        public virtual void ResetToken()
+        {
             Token = null;
         }
     }

--- a/src/Cortside.RestApiClient/Cortside.RestApiClient.csproj
+++ b/src/Cortside.RestApiClient/Cortside.RestApiClient.csproj
@@ -3,18 +3,18 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cortside.Common.Correlation" Version="6.2.403" />
-    <PackageReference Include="Cortside.Common.Json" Version="6.2.403" />
-    <PackageReference Include="Cortside.Common.Messages" Version="6.2.403" />
-    <PackageReference Include="Cortside.Common.Validation" Version="6.2.403" />
+    <PackageReference Include="Cortside.Common.Correlation" Version="6.2.408" />
+    <PackageReference Include="Cortside.Common.Json" Version="6.2.408" />
+    <PackageReference Include="Cortside.Common.Messages" Version="6.2.408" />
+    <PackageReference Include="Cortside.Common.Validation" Version="6.2.408" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.8.14">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Polly" Version="7.2.4" />
+    <PackageReference Include="Polly" Version="8.3.1" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />

--- a/src/Cortside.RestApiClient/RestApiClient.cs
+++ b/src/Cortside.RestApiClient/RestApiClient.cs
@@ -12,59 +12,77 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using RestSharp;
 
-namespace Cortside.RestApiClient {
-    public class RestApiClient : IDisposable, IRestApiClient {
+namespace Cortside.RestApiClient
+{
+    public class RestApiClient : IDisposable, IRestApiClient
+    {
         private readonly ILogger logger;
         private readonly RestClient client;
         private readonly RestApiClientOptions options;
         private readonly IHttpContextAccessor contextAccessor;
 
         [Obsolete("Use overload that takes IHttpContextAccessor")]
-        public RestApiClient(ILogger logger, string baseUrl) : this(logger, new HttpContextAccessor(), baseUrl) {
+        public RestApiClient(ILogger logger, string baseUrl) : this(logger, new HttpContextAccessor(), baseUrl)
+        {
         }
 
-        public RestApiClient(ILogger logger, IHttpContextAccessor contextAccessor, string baseUrl) : this(logger, contextAccessor, new RestApiClientOptions(baseUrl)) {
+        public RestApiClient(ILogger logger, IHttpContextAccessor contextAccessor, string baseUrl) : this(logger, contextAccessor, new RestApiClientOptions(baseUrl))
+        {
         }
 
         [Obsolete("Use overload that takes IHttpContextAccessor")]
-        public RestApiClient(ILogger logger, RestApiClientOptions options) : this(logger, new HttpContextAccessor(), options) {
+        public RestApiClient(ILogger logger, RestApiClientOptions options) : this(logger, new HttpContextAccessor(), options)
+        {
         }
 
-        public RestApiClient(ILogger logger, IHttpContextAccessor contextAccessor, RestApiClientOptions options, HttpClient httpClient = null) {
+        public RestApiClient(ILogger logger, IHttpContextAccessor contextAccessor, RestApiClientOptions options, HttpClient httpClient = null)
+        {
             this.logger = logger;
             this.options = options;
             this.contextAccessor = contextAccessor;
 
-            if (options.Serializer != null) {
-                if (httpClient != null) {
+            if (options.Serializer != null)
+            {
+                if (httpClient != null)
+                {
                     client = new RestClient(httpClient, options.Options, configureSerialization: s => s.UseSerializer(() => options.Serializer));
-                } else {
+                }
+                else
+                {
                     client = new RestClient(options.Options, configureSerialization: s => s.UseSerializer(() => options.Serializer));
                 }
             }
 
-            if (client == null) {
-                if (httpClient != null) {
+            if (client == null)
+            {
+                if (httpClient != null)
+                {
                     client = new RestClient(httpClient, options.Options, configureSerialization: s => s.UseDefaultSerializers());
-                } else {
+                }
+                else
+                {
                     client = new RestClient(options.Options, configureSerialization: s => s.UseDefaultSerializers());
                 }
             }
         }
 
-        public IDistributedCache Cache {
+        public IDistributedCache Cache
+        {
             get { return options.Cache; }
         }
 
         public Uri BuildUri(IRestApiRequest request) => client.BuildUri(request.RestRequest);
 
-        private void TimeoutCheck(IRestApiRequest request, RestResponse response) {
-            if (response.ResponseStatus == ResponseStatus.TimedOut) {
+        private void TimeoutCheck(IRestApiRequest request, RestResponse response)
+        {
+            if (response.ResponseStatus == ResponseStatus.TimedOut)
+            {
                 response.ErrorMessage = null;
                 response.ErrorException = null;
                 LogError(request, response);
 
-                if (options.ThrowOnAnyError) {
+                if (options.ThrowOnAnyError)
+                {
                     var timeouts = new int[] { request.Timeout, client.Options.MaxTimeout };
                     var timeout = timeouts.Where(x => x > 0).Min();
                     throw new TimeoutException($"Timeout of {timeout} exceeded");
@@ -72,11 +90,13 @@ namespace Cortside.RestApiClient {
             }
         }
 
-        private RestResponse<T> DeserializeRestResponse<T>(IRestApiRequest request, RestResponse response) {
+        private RestResponse<T> DeserializeRestResponse<T>(IRestApiRequest request, RestResponse response)
+        {
             var result = client.Deserialize<T>(response);
 
             var ex = result.ErrorException;
-            if ((options.ThrowOnDeserializationError || options.ThrowOnAnyError) && ex != null) {
+            if ((options.ThrowOnDeserializationError || options.ThrowOnAnyError) && ex != null)
+            {
                 LogError(request, result);
                 throw ex;
             }
@@ -84,7 +104,8 @@ namespace Cortside.RestApiClient {
             return result;
         }
 
-        protected async Task<RestResponse> InnerExecuteAsync(IRestApiRequest request) {
+        protected async Task<RestResponse> InnerExecuteAsync(IRestApiRequest request)
+        {
             var policy = request.Policy ?? options.Policy;
 
             var correlationId = CorrelationContext.GetCorrelationId();
@@ -93,13 +114,18 @@ namespace Cortside.RestApiClient {
             SetForwardedHeader(request);
 
             RestResponse response;
-            using (logger.BeginScope(new Dictionary<string, object> { ["RequestUrl"] = client.BuildUri(request.RestRequest) })) {
+            using (logger.BeginScope(new Dictionary<string, object> { ["RequestUrl"] = client.BuildUri(request.RestRequest) }))
+            {
                 int attempt = 0;
-                try {
+                try
+                {
                     response = await policy.ExecuteAsync(async () => await InnerExecuteAttemptAsync(request, attempt++))
                         .ConfigureAwait(false);
-                } catch (Exception ex) {
-                    response = new RestResponse() {
+                }
+                catch (Exception ex)
+                {
+                    response = new RestResponse()
+                    {
                         ErrorException = ex,
                         ErrorMessage = ex.Message,
                         IsSuccessStatusCode = false,
@@ -110,11 +136,13 @@ namespace Cortside.RestApiClient {
                 logger.LogInformation("Response from {url} returned with status code {StatusCode} and content: {Content}", client.BuildUri(request.RestRequest), response.StatusCode, response.Content);
                 TimeoutCheck(request, response);
                 var exception = response.ErrorException;
-                if (options.ThrowOnAnyError && exception != null) {
+                if (options.ThrowOnAnyError && exception != null)
+                {
                     throw exception;
                 }
 
-                if (response.StatusCode == HttpStatusCode.SeeOther && (request.FollowRedirects ?? options.FollowRedirects) && response.Headers?.Any(h => h.Name.Equals("location", StringComparison.InvariantCultureIgnoreCase)) == true) {
+                if (response.StatusCode == HttpStatusCode.SeeOther && (request.FollowRedirects ?? options.FollowRedirects) && response.Headers?.Any(h => h.Name.Equals("location", StringComparison.InvariantCultureIgnoreCase)) == true)
+                {
                     var url = response.Headers.FirstOrDefault(h => h.Name.Equals("location", StringComparison.InvariantCultureIgnoreCase)).Value.ToString();
                     logger.LogInformation($"Following redirect to {url}");
                     var redirectRequest = new RestApiRequest(url, Method.Get);
@@ -126,48 +154,58 @@ namespace Cortside.RestApiClient {
             return response;
         }
 
-        private async Task<RestResponse> InnerExecuteAttemptAsync(IRestApiRequest request, int attempt) {
+        private async Task<RestResponse> InnerExecuteAttemptAsync(IRestApiRequest request, int attempt)
+        {
             var url = client.BuildUri(request.RestRequest);
             var body = BuildContent(request);
             logger.LogDebug("Request to {url}, attempt {attempt}, with body {body}", url, attempt, body);
 
             var response = await client.ExecuteAsync(request.RestRequest).ConfigureAwait(false);
-            if (response.ErrorException != null || !string.IsNullOrWhiteSpace(response.ErrorMessage)) {
+            if (response.ErrorException != null || !string.IsNullOrWhiteSpace(response.ErrorMessage))
+            {
                 logger.LogError(response.ErrorException,
                     "Response {attempt}: Status Code = {StatusCode} ErrorMessage = {ErrorMessage} Content = {Content}", attempt,
                     response.StatusCode, response.ErrorMessage, response.Content);
-            } else {
+            }
+            else
+            {
                 logger.LogDebug("Response {attempt}: Status Code = {StatusCode} Content = {Content}", attempt, response.StatusCode,
                     response.Content);
             }
 
             var authenticator = options.Authenticator as IRestApiAuthenticator;
-            if (authenticator != null) {
-                authenticator.ClearToken();
+            if (authenticator != null)
+            {
+                authenticator.ResetToken();
             }
 
             if (request.Method == Method.Post && (response.StatusCode == HttpStatusCode.RedirectMethod ||
-                                                  response.StatusCode == HttpStatusCode.Redirect)) {
+                                                  response.StatusCode == HttpStatusCode.Redirect))
+            {
                 response.IsSuccessStatusCode = true;
                 response.ResponseStatus = ResponseStatus.Completed;
                 response.ErrorException = null;
             }
 
             TimeoutCheck(request, response);
-            if (options.ThrowOnAnyError && response.ErrorException != null) {
+            if (options.ThrowOnAnyError && response.ErrorException != null)
+            {
                 throw response.ErrorException;
             }
 
             return response;
         }
 
-        private void SetForwardedHeader(IRestApiRequest request) {
-            if (contextAccessor?.HttpContext?.Request == null) {
+        private void SetForwardedHeader(IRestApiRequest request)
+        {
+            if (contextAccessor?.HttpContext?.Request == null)
+            {
                 return;
             }
 
             var ip = HttpContextUtility.GetRequestIpAddress(contextAccessor.HttpContext);
-            if (string.IsNullOrWhiteSpace(ip)) {
+            if (string.IsNullOrWhiteSpace(ip))
+            {
                 return;
             }
 
@@ -175,44 +213,54 @@ namespace Cortside.RestApiClient {
             request.AddHeader("Forwarded", $"for={ip}");
         }
 
-        public Task<RestResponse> ExecuteAsync(IRestApiRequest request) {
+        public Task<RestResponse> ExecuteAsync(IRestApiRequest request)
+        {
             return InnerExecuteAsync(request);
         }
 
-        public async Task<RestResponse<T>> ExecuteAsync<T>(IRestApiRequest request) {
+        public async Task<RestResponse<T>> ExecuteAsync<T>(IRestApiRequest request)
+        {
             var response = await InnerExecuteAsync(request).ConfigureAwait(false);
             var result = DeserializeRestResponse<T>(request, response);
 
             return result;
         }
 
-        public async Task<RestResponse> GetAsync(IRestApiRequest request) {
+        public async Task<RestResponse> GetAsync(IRestApiRequest request)
+        {
             request.Method = Method.Get;
             var response = await InnerExecuteAsync(request).ConfigureAwait(false);
 
             // TODO: move to InnerExecuteAsync and add as ErrorException?
-            if (response.ResponseStatus == ResponseStatus.TimedOut && options.ThrowOnAnyError) {
+            if (response.ResponseStatus == ResponseStatus.TimedOut && options.ThrowOnAnyError)
+            {
                 var timeouts = new int[] { request.Timeout, client.Options.MaxTimeout };
                 var timeout = timeouts.Where(x => x > 0).Min();
                 throw new TimeoutException($"Timeout of {timeout} exceeded");
             }
 
-            if (response.ErrorException != null && options.ThrowOnAnyError) {
+            if (response.ErrorException != null && options.ThrowOnAnyError)
+            {
                 LogError(request, response);
                 // Request failed with status code Forbidden
                 throw new RestApiException(response.ErrorMessage ?? response.ErrorException.Message, response.ErrorException);
             }
 
-            if (!response.IsSuccessful && options.ThrowOnAnyError) {
+            if (!response.IsSuccessful && options.ThrowOnAnyError)
+            {
                 LogError(request, response);
                 throw new RestApiException($"Request failed with status code {response.StatusCode}");
             }
 
-            if (response.StatusCode == System.Net.HttpStatusCode.OK) {
+            if (response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
                 return response;
-            } else {
+            }
+            else
+            {
                 LogError(request, response);
-                if (options.ThrowOnAnyError) {
+                if (options.ThrowOnAnyError)
+                {
                     throw new RestApiException("unsuccessful request--need better message");
                 }
 
@@ -220,10 +268,12 @@ namespace Cortside.RestApiClient {
             }
         }
 
-        public async Task<RestResponse<T>> GetAsync<T>(IRestApiRequest request) where T : new() {
+        public async Task<RestResponse<T>> GetAsync<T>(IRestApiRequest request) where T : new()
+        {
             var response = await GetAsync(request).ConfigureAwait(false);
 
-            if (response.StatusCode == System.Net.HttpStatusCode.OK) {
+            if (response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
                 var result = DeserializeRestResponse<T>(request, response);
                 return result;
             }
@@ -232,26 +282,33 @@ namespace Cortside.RestApiClient {
             return RestResponse<T>.FromResponse(response);
         }
 
-        public Task<T> GetWithCacheAsync<T>(IRestApiRequest request, TimeSpan? duration = null) where T : class, new() {
+        public Task<T> GetWithCacheAsync<T>(IRestApiRequest request, TimeSpan? duration = null) where T : class, new()
+        {
             var cacheKey = $"RestRequest::{client.BuildUri(request.RestRequest)}::{request.RestRequest.QueryParameters()}";
             return GetWithCacheAsync<T>(request, cacheKey, duration);
         }
 
-        public async Task<T> GetWithCacheAsync<T>(IRestApiRequest request, string cacheKey, TimeSpan? duration = null) where T : class, new() {
+        public async Task<T> GetWithCacheAsync<T>(IRestApiRequest request, string cacheKey, TimeSpan? duration = null) where T : class, new()
+        {
             duration ??= TimeSpan.FromMinutes(10);
             var cacheOptions = new DistributedCacheEntryOptions() { AbsoluteExpirationRelativeToNow = duration };
 
             var item = await Cache.GetValueAsync<T>(cacheKey, options.Serializer).ConfigureAwait(false);
-            if (item == null) {
+            if (item == null)
+            {
                 var response = await GetAsync<T>(request).ConfigureAwait(false);
 
-                if (response.StatusCode == System.Net.HttpStatusCode.OK) {
+                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                {
                     await Cache.SetValueAsync(cacheKey, response.Data, options.Serializer, cacheOptions).ConfigureAwait(false);
                     item = response.Data;
-                } else {
+                }
+                else
+                {
                     LogError(request, response);
                     var ex = response.ErrorException;
-                    if (ex != null && options.ThrowOnAnyError) {
+                    if (ex != null && options.ThrowOnAnyError)
+                    {
                         throw ex;
                     }
                     return default;
@@ -261,7 +318,8 @@ namespace Cortside.RestApiClient {
             return item;
         }
 
-        private void LogError(IRestApiRequest request, RestResponse response) {
+        private void LogError(IRestApiRequest request, RestResponse response)
+        {
             //Get the values of the parameters passed to the API
             string parameters = request.RestRequest.QueryParameters();
 
@@ -273,9 +331,12 @@ namespace Cortside.RestApiClient {
 
             //Acquire the actual exception
             Exception ex;
-            if (response?.ErrorException != null) {
+            if (response?.ErrorException != null)
+            {
                 ex = response.ErrorException;
-            } else {
+            }
+            else
+            {
                 ex = new Exception(info);
                 info = string.Empty;
             }
@@ -285,28 +346,33 @@ namespace Cortside.RestApiClient {
         }
 
         // TODO: use internal method from RestSharp that handles everything correctly
-        public string BuildContent(IRestApiRequest request) {
+        public string BuildContent(IRestApiRequest request)
+        {
             var body = request.Parameters.SingleOrDefault(x => x.Type == ParameterType.RequestBody);
-            if (body != null) {
+            if (body != null)
+            {
                 var serializer = options.Serializer ?? new JsonNetSerializer();
                 return serializer.Serialize(body);
             }
 
             var postParameters = request.Method == Method.Post ? request.Parameters.GetParameters<GetOrPostParameter>() : Enumerable.Empty<GetOrPostParameter>();
             var sb = new StringBuilder();
-            foreach (var postParameter in postParameters) {
+            foreach (var postParameter in postParameters)
+            {
                 sb.Append(postParameter.Name).Append("=").AppendLine(postParameter.Value?.ToString() ?? string.Empty);
             }
 
             return sb.ToString();
         }
 
-        public void Dispose() {
+        public void Dispose()
+        {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing) {
+        protected virtual void Dispose(bool disposing)
+        {
             client?.Dispose();
         }
     }

--- a/src/Cortside.RestApiClient/RestApiClient.cs
+++ b/src/Cortside.RestApiClient/RestApiClient.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Cortside.Common.Correlation;
+using Cortside.RestApiClient.Authenticators;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
@@ -138,6 +139,11 @@ namespace Cortside.RestApiClient {
             } else {
                 logger.LogDebug("Response {attempt}: Status Code = {StatusCode} Content = {Content}", attempt, response.StatusCode,
                     response.Content);
+            }
+
+            var authenticator = options.Authenticator as IRestApiAuthenticator;
+            if (authenticator != null) {
+                authenticator.ClearToken();
             }
 
             if (request.Method == Method.Post && (response.StatusCode == HttpStatusCode.RedirectMethod ||

--- a/src/Cortside.RestApiClient/RestApiClient.cs
+++ b/src/Cortside.RestApiClient/RestApiClient.cs
@@ -12,77 +12,59 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using RestSharp;
 
-namespace Cortside.RestApiClient
-{
-    public class RestApiClient : IDisposable, IRestApiClient
-    {
+namespace Cortside.RestApiClient {
+    public class RestApiClient : IDisposable, IRestApiClient {
         private readonly ILogger logger;
         private readonly RestClient client;
         private readonly RestApiClientOptions options;
         private readonly IHttpContextAccessor contextAccessor;
 
         [Obsolete("Use overload that takes IHttpContextAccessor")]
-        public RestApiClient(ILogger logger, string baseUrl) : this(logger, new HttpContextAccessor(), baseUrl)
-        {
+        public RestApiClient(ILogger logger, string baseUrl) : this(logger, new HttpContextAccessor(), baseUrl) {
         }
 
-        public RestApiClient(ILogger logger, IHttpContextAccessor contextAccessor, string baseUrl) : this(logger, contextAccessor, new RestApiClientOptions(baseUrl))
-        {
+        public RestApiClient(ILogger logger, IHttpContextAccessor contextAccessor, string baseUrl) : this(logger, contextAccessor, new RestApiClientOptions(baseUrl)) {
         }
 
         [Obsolete("Use overload that takes IHttpContextAccessor")]
-        public RestApiClient(ILogger logger, RestApiClientOptions options) : this(logger, new HttpContextAccessor(), options)
-        {
+        public RestApiClient(ILogger logger, RestApiClientOptions options) : this(logger, new HttpContextAccessor(), options) {
         }
 
-        public RestApiClient(ILogger logger, IHttpContextAccessor contextAccessor, RestApiClientOptions options, HttpClient httpClient = null)
-        {
+        public RestApiClient(ILogger logger, IHttpContextAccessor contextAccessor, RestApiClientOptions options, HttpClient httpClient = null) {
             this.logger = logger;
             this.options = options;
             this.contextAccessor = contextAccessor;
 
-            if (options.Serializer != null)
-            {
-                if (httpClient != null)
-                {
+            if (options.Serializer != null) {
+                if (httpClient != null) {
                     client = new RestClient(httpClient, options.Options, configureSerialization: s => s.UseSerializer(() => options.Serializer));
-                }
-                else
-                {
+                } else {
                     client = new RestClient(options.Options, configureSerialization: s => s.UseSerializer(() => options.Serializer));
                 }
             }
 
-            if (client == null)
-            {
-                if (httpClient != null)
-                {
+            if (client == null) {
+                if (httpClient != null) {
                     client = new RestClient(httpClient, options.Options, configureSerialization: s => s.UseDefaultSerializers());
-                }
-                else
-                {
+                } else {
                     client = new RestClient(options.Options, configureSerialization: s => s.UseDefaultSerializers());
                 }
             }
         }
 
-        public IDistributedCache Cache
-        {
+        public IDistributedCache Cache {
             get { return options.Cache; }
         }
 
         public Uri BuildUri(IRestApiRequest request) => client.BuildUri(request.RestRequest);
 
-        private void TimeoutCheck(IRestApiRequest request, RestResponse response)
-        {
-            if (response.ResponseStatus == ResponseStatus.TimedOut)
-            {
+        private void TimeoutCheck(IRestApiRequest request, RestResponse response) {
+            if (response.ResponseStatus == ResponseStatus.TimedOut) {
                 response.ErrorMessage = null;
                 response.ErrorException = null;
                 LogError(request, response);
 
-                if (options.ThrowOnAnyError)
-                {
+                if (options.ThrowOnAnyError) {
                     var timeouts = new int[] { request.Timeout, client.Options.MaxTimeout };
                     var timeout = timeouts.Where(x => x > 0).Min();
                     throw new TimeoutException($"Timeout of {timeout} exceeded");
@@ -90,13 +72,11 @@ namespace Cortside.RestApiClient
             }
         }
 
-        private RestResponse<T> DeserializeRestResponse<T>(IRestApiRequest request, RestResponse response)
-        {
+        private RestResponse<T> DeserializeRestResponse<T>(IRestApiRequest request, RestResponse response) {
             var result = client.Deserialize<T>(response);
 
             var ex = result.ErrorException;
-            if ((options.ThrowOnDeserializationError || options.ThrowOnAnyError) && ex != null)
-            {
+            if ((options.ThrowOnDeserializationError || options.ThrowOnAnyError) && ex != null) {
                 LogError(request, result);
                 throw ex;
             }
@@ -104,8 +84,7 @@ namespace Cortside.RestApiClient
             return result;
         }
 
-        protected async Task<RestResponse> InnerExecuteAsync(IRestApiRequest request)
-        {
+        protected async Task<RestResponse> InnerExecuteAsync(IRestApiRequest request) {
             var policy = request.Policy ?? options.Policy;
 
             var correlationId = CorrelationContext.GetCorrelationId();
@@ -114,18 +93,13 @@ namespace Cortside.RestApiClient
             SetForwardedHeader(request);
 
             RestResponse response;
-            using (logger.BeginScope(new Dictionary<string, object> { ["RequestUrl"] = client.BuildUri(request.RestRequest) }))
-            {
+            using (logger.BeginScope(new Dictionary<string, object> { ["RequestUrl"] = client.BuildUri(request.RestRequest) })) {
                 int attempt = 0;
-                try
-                {
+                try {
                     response = await policy.ExecuteAsync(async () => await InnerExecuteAttemptAsync(request, attempt++))
                         .ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    response = new RestResponse()
-                    {
+                } catch (Exception ex) {
+                    response = new RestResponse() {
                         ErrorException = ex,
                         ErrorMessage = ex.Message,
                         IsSuccessStatusCode = false,
@@ -136,13 +110,11 @@ namespace Cortside.RestApiClient
                 logger.LogInformation("Response from {url} returned with status code {StatusCode} and content: {Content}", client.BuildUri(request.RestRequest), response.StatusCode, response.Content);
                 TimeoutCheck(request, response);
                 var exception = response.ErrorException;
-                if (options.ThrowOnAnyError && exception != null)
-                {
+                if (options.ThrowOnAnyError && exception != null) {
                     throw exception;
                 }
 
-                if (response.StatusCode == HttpStatusCode.SeeOther && (request.FollowRedirects ?? options.FollowRedirects) && response.Headers?.Any(h => h.Name.Equals("location", StringComparison.InvariantCultureIgnoreCase)) == true)
-                {
+                if (response.StatusCode == HttpStatusCode.SeeOther && (request.FollowRedirects ?? options.FollowRedirects) && response.Headers?.Any(h => h.Name.Equals("location", StringComparison.InvariantCultureIgnoreCase)) == true) {
                     var url = response.Headers.FirstOrDefault(h => h.Name.Equals("location", StringComparison.InvariantCultureIgnoreCase)).Value.ToString();
                     logger.LogInformation($"Following redirect to {url}");
                     var redirectRequest = new RestApiRequest(url, Method.Get);
@@ -154,58 +126,48 @@ namespace Cortside.RestApiClient
             return response;
         }
 
-        private async Task<RestResponse> InnerExecuteAttemptAsync(IRestApiRequest request, int attempt)
-        {
+        private async Task<RestResponse> InnerExecuteAttemptAsync(IRestApiRequest request, int attempt) {
             var url = client.BuildUri(request.RestRequest);
             var body = BuildContent(request);
             logger.LogDebug("Request to {url}, attempt {attempt}, with body {body}", url, attempt, body);
 
             var response = await client.ExecuteAsync(request.RestRequest).ConfigureAwait(false);
-            if (response.ErrorException != null || !string.IsNullOrWhiteSpace(response.ErrorMessage))
-            {
+            if (response.ErrorException != null || !string.IsNullOrWhiteSpace(response.ErrorMessage)) {
                 logger.LogError(response.ErrorException,
                     "Response {attempt}: Status Code = {StatusCode} ErrorMessage = {ErrorMessage} Content = {Content}", attempt,
                     response.StatusCode, response.ErrorMessage, response.Content);
-            }
-            else
-            {
+            } else {
                 logger.LogDebug("Response {attempt}: Status Code = {StatusCode} Content = {Content}", attempt, response.StatusCode,
                     response.Content);
             }
 
             var authenticator = options.Authenticator as IRestApiAuthenticator;
-            if (authenticator != null)
-            {
-                authenticator.ResetToken();
+            if (authenticator != null && response.StatusCode == HttpStatusCode.Unauthorized) {
+                authenticator.HandleUnauthorizedClientRequest();
             }
 
             if (request.Method == Method.Post && (response.StatusCode == HttpStatusCode.RedirectMethod ||
-                                                  response.StatusCode == HttpStatusCode.Redirect))
-            {
+                                                  response.StatusCode == HttpStatusCode.Redirect)) {
                 response.IsSuccessStatusCode = true;
                 response.ResponseStatus = ResponseStatus.Completed;
                 response.ErrorException = null;
             }
 
             TimeoutCheck(request, response);
-            if (options.ThrowOnAnyError && response.ErrorException != null)
-            {
+            if (options.ThrowOnAnyError && response.ErrorException != null) {
                 throw response.ErrorException;
             }
 
             return response;
         }
 
-        private void SetForwardedHeader(IRestApiRequest request)
-        {
-            if (contextAccessor?.HttpContext?.Request == null)
-            {
+        private void SetForwardedHeader(IRestApiRequest request) {
+            if (contextAccessor?.HttpContext?.Request == null) {
                 return;
             }
 
             var ip = HttpContextUtility.GetRequestIpAddress(contextAccessor.HttpContext);
-            if (string.IsNullOrWhiteSpace(ip))
-            {
+            if (string.IsNullOrWhiteSpace(ip)) {
                 return;
             }
 
@@ -213,54 +175,44 @@ namespace Cortside.RestApiClient
             request.AddHeader("Forwarded", $"for={ip}");
         }
 
-        public Task<RestResponse> ExecuteAsync(IRestApiRequest request)
-        {
+        public Task<RestResponse> ExecuteAsync(IRestApiRequest request) {
             return InnerExecuteAsync(request);
         }
 
-        public async Task<RestResponse<T>> ExecuteAsync<T>(IRestApiRequest request)
-        {
+        public async Task<RestResponse<T>> ExecuteAsync<T>(IRestApiRequest request) {
             var response = await InnerExecuteAsync(request).ConfigureAwait(false);
             var result = DeserializeRestResponse<T>(request, response);
 
             return result;
         }
 
-        public async Task<RestResponse> GetAsync(IRestApiRequest request)
-        {
+        public async Task<RestResponse> GetAsync(IRestApiRequest request) {
             request.Method = Method.Get;
             var response = await InnerExecuteAsync(request).ConfigureAwait(false);
 
             // TODO: move to InnerExecuteAsync and add as ErrorException?
-            if (response.ResponseStatus == ResponseStatus.TimedOut && options.ThrowOnAnyError)
-            {
+            if (response.ResponseStatus == ResponseStatus.TimedOut && options.ThrowOnAnyError) {
                 var timeouts = new int[] { request.Timeout, client.Options.MaxTimeout };
                 var timeout = timeouts.Where(x => x > 0).Min();
                 throw new TimeoutException($"Timeout of {timeout} exceeded");
             }
 
-            if (response.ErrorException != null && options.ThrowOnAnyError)
-            {
+            if (response.ErrorException != null && options.ThrowOnAnyError) {
                 LogError(request, response);
                 // Request failed with status code Forbidden
                 throw new RestApiException(response.ErrorMessage ?? response.ErrorException.Message, response.ErrorException);
             }
 
-            if (!response.IsSuccessful && options.ThrowOnAnyError)
-            {
+            if (!response.IsSuccessful && options.ThrowOnAnyError) {
                 LogError(request, response);
                 throw new RestApiException($"Request failed with status code {response.StatusCode}");
             }
 
-            if (response.StatusCode == System.Net.HttpStatusCode.OK)
-            {
+            if (response.StatusCode == System.Net.HttpStatusCode.OK) {
                 return response;
-            }
-            else
-            {
+            } else {
                 LogError(request, response);
-                if (options.ThrowOnAnyError)
-                {
+                if (options.ThrowOnAnyError) {
                     throw new RestApiException("unsuccessful request--need better message");
                 }
 
@@ -268,12 +220,10 @@ namespace Cortside.RestApiClient
             }
         }
 
-        public async Task<RestResponse<T>> GetAsync<T>(IRestApiRequest request) where T : new()
-        {
+        public async Task<RestResponse<T>> GetAsync<T>(IRestApiRequest request) where T : new() {
             var response = await GetAsync(request).ConfigureAwait(false);
 
-            if (response.StatusCode == System.Net.HttpStatusCode.OK)
-            {
+            if (response.StatusCode == System.Net.HttpStatusCode.OK) {
                 var result = DeserializeRestResponse<T>(request, response);
                 return result;
             }
@@ -282,33 +232,26 @@ namespace Cortside.RestApiClient
             return RestResponse<T>.FromResponse(response);
         }
 
-        public Task<T> GetWithCacheAsync<T>(IRestApiRequest request, TimeSpan? duration = null) where T : class, new()
-        {
+        public Task<T> GetWithCacheAsync<T>(IRestApiRequest request, TimeSpan? duration = null) where T : class, new() {
             var cacheKey = $"RestRequest::{client.BuildUri(request.RestRequest)}::{request.RestRequest.QueryParameters()}";
             return GetWithCacheAsync<T>(request, cacheKey, duration);
         }
 
-        public async Task<T> GetWithCacheAsync<T>(IRestApiRequest request, string cacheKey, TimeSpan? duration = null) where T : class, new()
-        {
+        public async Task<T> GetWithCacheAsync<T>(IRestApiRequest request, string cacheKey, TimeSpan? duration = null) where T : class, new() {
             duration ??= TimeSpan.FromMinutes(10);
             var cacheOptions = new DistributedCacheEntryOptions() { AbsoluteExpirationRelativeToNow = duration };
 
             var item = await Cache.GetValueAsync<T>(cacheKey, options.Serializer).ConfigureAwait(false);
-            if (item == null)
-            {
+            if (item == null) {
                 var response = await GetAsync<T>(request).ConfigureAwait(false);
 
-                if (response.StatusCode == System.Net.HttpStatusCode.OK)
-                {
+                if (response.StatusCode == System.Net.HttpStatusCode.OK) {
                     await Cache.SetValueAsync(cacheKey, response.Data, options.Serializer, cacheOptions).ConfigureAwait(false);
                     item = response.Data;
-                }
-                else
-                {
+                } else {
                     LogError(request, response);
                     var ex = response.ErrorException;
-                    if (ex != null && options.ThrowOnAnyError)
-                    {
+                    if (ex != null && options.ThrowOnAnyError) {
                         throw ex;
                     }
                     return default;
@@ -318,8 +261,7 @@ namespace Cortside.RestApiClient
             return item;
         }
 
-        private void LogError(IRestApiRequest request, RestResponse response)
-        {
+        private void LogError(IRestApiRequest request, RestResponse response) {
             //Get the values of the parameters passed to the API
             string parameters = request.RestRequest.QueryParameters();
 
@@ -331,12 +273,9 @@ namespace Cortside.RestApiClient
 
             //Acquire the actual exception
             Exception ex;
-            if (response?.ErrorException != null)
-            {
+            if (response?.ErrorException != null) {
                 ex = response.ErrorException;
-            }
-            else
-            {
+            } else {
                 ex = new Exception(info);
                 info = string.Empty;
             }
@@ -346,33 +285,28 @@ namespace Cortside.RestApiClient
         }
 
         // TODO: use internal method from RestSharp that handles everything correctly
-        public string BuildContent(IRestApiRequest request)
-        {
+        public string BuildContent(IRestApiRequest request) {
             var body = request.Parameters.SingleOrDefault(x => x.Type == ParameterType.RequestBody);
-            if (body != null)
-            {
+            if (body != null) {
                 var serializer = options.Serializer ?? new JsonNetSerializer();
                 return serializer.Serialize(body);
             }
 
             var postParameters = request.Method == Method.Post ? request.Parameters.GetParameters<GetOrPostParameter>() : Enumerable.Empty<GetOrPostParameter>();
             var sb = new StringBuilder();
-            foreach (var postParameter in postParameters)
-            {
+            foreach (var postParameter in postParameters) {
                 sb.Append(postParameter.Name).Append("=").AppendLine(postParameter.Value?.ToString() ?? string.Empty);
             }
 
             return sb.ToString();
         }
 
-        public void Dispose()
-        {
+        public void Dispose() {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
-        {
+        protected virtual void Dispose(bool disposing) {
             client?.Dispose();
         }
     }

--- a/src/Cortside.RestApiClient/RestApiClientOptions.cs
+++ b/src/Cortside.RestApiClient/RestApiClientOptions.cs
@@ -62,12 +62,7 @@ namespace Cortside.RestApiClient {
 
         public IAuthenticator Authenticator {
             get { return rcOptions.Authenticator; }
-            set {
-                rcOptions.Authenticator = value;
-                if (rcOptions.Authenticator != null) {
-
-                }
-            }
+            set { rcOptions.Authenticator = value; }
         }
 
         public IRestSerializer Serializer { get; set; }


### PR DESCRIPTION
support for authenticator to clear token on 401 response

Introduced `IRestApiAuthenticator` that has method named `HandleUnauthorizedClientRequest` to allow for the authenticator to decide what to do on client authorization failure.  New abstract `RestApiAuthenticator` class implementation will set the internal `Token` to null so that subsequent client request will request a new token.


